### PR TITLE
loader: Add ACPI RSDP address to boot_params

### DIFF
--- a/src/loader/bootparam.rs
+++ b/src/loader/bootparam.rs
@@ -3495,7 +3495,8 @@ pub struct boot_params {
     pub _pad2: [__u8; 4usize],
     pub tboot_addr: __u64,
     pub ist_info: ist_info,
-    pub _pad3: [__u8; 16usize],
+    pub acpi_rsdp_addr: __u64,
+    pub _pad3: [__u8; 8usize],
     pub hd0_info: [__u8; 16usize],
     pub hd1_info: [__u8; 16usize],
     pub sys_desc_table: sys_desc_table,
@@ -3586,8 +3587,18 @@ fn bindgen_test_layout_boot_params() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const boot_params))._pad3 as *const _ as usize },
+        unsafe { &(*(0 as *const boot_params)).acpi_rsdp_addr as *const _ as usize },
         112usize,
+        concat!(
+            "Alignment of field: ",
+            stringify!(boot_params),
+            "::",
+            stringify!(acpi_rsdp_addr)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(0 as *const boot_params))._pad3 as *const _ as usize },
+        120usize,
         concat!(
             "Alignment of field: ",
             stringify!(boot_params),


### PR DESCRIPTION
As per changes to the Linux kernel boot_params struct add the ACPI RSDP
address.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>