### PR TITLE
loader: Update for latest vm-memory changes

### DIFF
--- a/src/loader/mod.rs
+++ b/src/loader/mod.rs
@@ -398,7 +398,7 @@ pub fn load_cmdline<M: GuestMemory>(
     let end = guest_addr
         .checked_add(len as u64 + 1)
         .ok_or(Error::CommandLineOverflow)?; // Extra for null termination.
-    if end > guest_mem.end_addr() {
+    if end > guest_mem.last_addr() {
         return Err(Error::CommandLineOverflow)?;
     }
 


### PR DESCRIPTION
The method GuestMemory::end_addr() was renamed.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>