### PR TITLE
build: Bump the minimum version of vm-memory

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ elf = []
 bzimage = []
 
 [dependencies]
-vm-memory = {version = "0.1.0", features = ["backend-mmap"]}
+vm-memory = {version = "0.2.0", features = ["backend-mmap"]}

--- a/coverage_config_aarch64.json
+++ b/coverage_config_aarch64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 70.9,
+  "coverage_score": 71.4,
   "exclude_path": "",
   "crate_features": ""
 }


### PR DESCRIPTION
"0.1.0" means every version >= 0.1.0 < 0.2.0 but this breaks as the
latest vm-memory release is 0.2.0.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>