### PR TITLE
Boot configurator: trait (and associated objects) that write boot params in guest memory

### DIFF
--- a/coverage_config_aarch64.json
+++ b/coverage_config_aarch64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 75.7,
+  "coverage_score": 77.2,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/coverage_config_aarch64.json
+++ b/coverage_config_aarch64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 77.2,
+  "coverage_score": 79.9,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/coverage_config_aarch64.json
+++ b/coverage_config_aarch64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 79.9,
+  "coverage_score": 80.3,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 77.8,
+  "coverage_score": 78.5,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 74.8,
+  "coverage_score": 77.8,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/src/configurator/aarch64/fdt.rs
+++ b/src/configurator/aarch64/fdt.rs
@@ -59,7 +59,7 @@ impl BootConfigurator for FdtBootConfigurator {
     {
         // The VMM has filled an FDT and passed it as a `ByteValued` object.
         guest_memory
-            .write_slice(params.header.0.as_slice(), params.header.1)
+            .write_slice(params.header.as_slice(), params.header_start)
             .map_err(|_| Error::WriteFDTToMemory.into())
     }
 }

--- a/src/configurator/aarch64/fdt.rs
+++ b/src/configurator/aarch64/fdt.rs
@@ -1,0 +1,72 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
+
+//! Traits and structs for loading the device tree.
+
+use vm_memory::{ByteValued, Bytes, GuestAddress, GuestMemory};
+
+use std::error::Error as StdError;
+use std::fmt;
+
+use super::super::{BootConfigurator, Error as BootConfiguratorError, Result};
+
+/// Errors specific to the device tree boot protocol configuration.
+#[derive(Debug, PartialEq)]
+pub enum Error {
+    /// Error writing FDT in memory.
+    WriteFDTToMemory,
+}
+
+impl StdError for Error {
+    fn description(&self) -> &str {
+        use Error::*;
+        match self {
+            WriteFDTToMemory => "Error writing FDT in guest memory.",
+        }
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "Device Tree Boot Configurator Error: {}",
+            StdError::description(self)
+        )
+    }
+}
+
+impl From<Error> for BootConfiguratorError {
+    fn from(err: Error) -> Self {
+        BootConfiguratorError::Fdt(err)
+    }
+}
+
+/// Boot configurator for device tree.
+pub struct FdtBootConfigurator {}
+
+impl BootConfigurator for FdtBootConfigurator {
+    /// Writes the boot parameters (configured elsewhere) into guest memory.
+    ///
+    /// # Arguments
+    ///
+    /// * `fdt` - flattened device tree.
+    /// * `sections` - unused.
+    /// * `guest_memory` - guest's physical memory.
+    fn write_bootparams<T, S, M>(
+        fdt: (T, GuestAddress),
+        _sections: Option<(Vec<S>, GuestAddress)>,
+        guest_memory: &M,
+    ) -> Result<()>
+    where
+        T: ByteValued,
+        S: ByteValued,
+        M: GuestMemory,
+    {
+        // The VMM has filled an FDT and passed it as a `ByteValued` object.
+        guest_memory
+            .write_obj(fdt.0, fdt.1)
+            .map_err(|_| Error::WriteFDTToMemory.into())
+    }
+}

--- a/src/configurator/aarch64/mod.rs
+++ b/src/configurator/aarch64/mod.rs
@@ -6,24 +6,4 @@
 
 #![cfg(target_arch = "aarch64")]
 
-use std::error::Error as StdError;
-use std::fmt;
-
-/// Placeholder error type.
-#[derive(Debug, PartialEq)]
-pub enum Error {
-    /// Placeholder error value.
-    Placeholder,
-}
-
-impl StdError for Error {
-    fn description(&self) -> &str {
-        unimplemented!()
-    }
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, _f: &mut fmt::Formatter) -> fmt::Result {
-        unimplemented!()
-    }
-}
+pub mod fdt;

--- a/src/configurator/aarch64/mod.rs
+++ b/src/configurator/aarch64/mod.rs
@@ -1,0 +1,29 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
+
+//! Traits and structs for configuring and loading boot parameters on `aarch64`.
+
+#![cfg(target_arch = "aarch64")]
+
+use std::error::Error as StdError;
+use std::fmt;
+
+/// Placeholder error type.
+#[derive(Debug, PartialEq)]
+pub enum Error {
+    /// Placeholder error value.
+    Placeholder,
+}
+
+impl StdError for Error {
+    fn description(&self) -> &str {
+        unimplemented!()
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+        unimplemented!()
+    }
+}

--- a/src/configurator/mod.rs
+++ b/src/configurator/mod.rs
@@ -29,7 +29,7 @@ pub use x86_64::*;
 #[cfg(target_arch = "aarch64")]
 mod aarch64;
 #[cfg(target_arch = "aarch64")]
-pub use aarch64::Error as ArmError;
+pub use aarch64::*;
 
 /// Errors specific to boot protocol configuration.
 #[derive(Debug, PartialEq)]
@@ -42,7 +42,7 @@ pub enum Error {
     Pvh(pvh::Error),
     /// Errors specific to device tree boot configuration.
     #[cfg(target_arch = "aarch64")]
-    Arm(ArmError),
+    Fdt(fdt::Error),
 }
 
 impl StdError for Error {
@@ -54,7 +54,7 @@ impl StdError for Error {
             #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
             Pvh(ref e) => e.description(),
             #[cfg(target_arch = "aarch64")]
-            Arm(ref e) => e.description(),
+            Fdt(ref e) => e.description(),
         }
     }
 }

--- a/src/configurator/mod.rs
+++ b/src/configurator/mod.rs
@@ -1,0 +1,116 @@
+// Copyright © 2020, Oracle and/or its affiliates.
+//
+// Copyright (c) 2019 Intel Corporation. All rights reserved.
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE-BSD-3-Clause file.
+//
+// SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
+
+//! Traits and structs for configuring and loading boot parameters.
+//! - [BootConfigurator](trait.BootConfigurator.html): configure boot parameters.
+//! - [LinuxBootConfigurator](linux/struct.LinuxBootConfigurator.html): Linux boot protocol
+//!   parameters configurator.
+//! - [PvhBootConfigurator](pvh/struct.PvhBootConfigurator.html): PVH boot protocol parameters
+//!   configurator.
+
+use vm_memory::{ByteValued, GuestAddress, GuestMemory};
+
+use std::error::Error as StdError;
+use std::fmt;
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+mod x86_64;
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+pub use x86_64::*;
+
+#[cfg(target_arch = "aarch64")]
+mod aarch64;
+#[cfg(target_arch = "aarch64")]
+pub use aarch64::Error as ArmError;
+
+/// Errors specific to boot protocol configuration.
+#[derive(Debug, PartialEq)]
+pub enum Error {
+    /// Errors specific to the Linux boot protocol configuration.
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    Linux(linux::Error),
+    /// Errors specific to the PVH boot protocol configuration.
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    Pvh(pvh::Error),
+    /// Errors specific to device tree boot configuration.
+    #[cfg(target_arch = "aarch64")]
+    Arm(ArmError),
+}
+
+impl StdError for Error {
+    fn description(&self) -> &str {
+        use Error::*;
+        match self {
+            #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+            Linux(ref e) => e.description(),
+            #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+            Pvh(ref e) => e.description(),
+            #[cfg(target_arch = "aarch64")]
+            Arm(ref e) => e.description(),
+        }
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "Boot Configurator Error: {}",
+            StdError::description(self)
+        )
+    }
+}
+
+/// A specialized `Result` type for the boot configurator.
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Trait that defines interfaces for building (TBD) and configuring boot parameters.
+///
+/// Currently, this trait exposes a single function which writes user-provided boot parameters into
+/// guest memory at the user-specified addresses. It's meant to be called after the kernel is
+/// loaded and after the boot parameters are built externally (in the VMM).
+///
+/// This trait will be extended with additional functionality to build boot parameters.
+pub trait BootConfigurator {
+    /// Writes the boot parameters (configured elsewhere) into guest memory.
+    ///
+    /// The arguments are split into `header` and `sections` to accommodate different boot
+    /// protocols like Linux boot and PVH. In Linux boot, the e820 map could be considered as
+    /// `sections`, but it's already encapsulated in the `boot_params` and thus all the boot
+    /// parameters are passed through a single struct. In PVH, the memory map table is separated
+    /// from the `hvm_start_info` struct, therefore it's passed separately.
+    ///
+    /// # Arguments
+    ///
+    /// * `header` - header section of the boot parameters and address where to write it in guest
+    ///              memory. The first element must be a POD struct that implements [`ByteValued`].
+    ///              For the Linux protocol it's the [`boot_params`] struct, and for PVH the
+    ///             [`hvm_start_info`] struct.
+    /// * `sections` - vector of sections that compose the boot parameters and address where to
+    ///                write them in guest memory. Unused for the Linux protocol. For PVH, it's the
+    ///                memory map table represented as a vector of [`hvm_memmap_table_entry`]. Must
+    ///                be a `Vec` of POD data structs that implement [`ByteValued`].
+    /// * `guest_memory` - guest's physical memory.
+    ///
+    /// [`boot_params`]: ../loader/bootparam/struct.boot_e820_entry.html
+    /// [`hvm_memmap_table_entry`]: ../loader/elf/start_info/struct.hvm_memmap_table_entry.html
+    /// [`hvm_start_info`]: ../loader/elf/start_info/struct.hvm_start_info.html
+    /// [`ByteValued`]: https://docs.rs/vm-memory/latest/vm_memory/bytes/trait.ByteValued.html
+    fn write_bootparams<T, S, M>(
+        header: (T, GuestAddress),
+        sections: Option<(Vec<S>, GuestAddress)>,
+        guest_memory: &M,
+    ) -> Result<()>
+    where
+        T: ByteValued,
+        S: ByteValued,
+        M: GuestMemory;
+}

--- a/src/configurator/mod.rs
+++ b/src/configurator/mod.rs
@@ -16,7 +16,7 @@
 //! - [PvhBootConfigurator](pvh/struct.PvhBootConfigurator.html): PVH boot protocol parameters
 //!   configurator.
 
-use vm_memory::{ByteValued, GuestAddress, GuestMemory};
+use vm_memory::{Address, ByteValued, GuestAddress, GuestMemory};
 
 use std::error::Error as StdError;
 use std::fmt;
@@ -30,6 +30,8 @@ pub use x86_64::*;
 mod aarch64;
 #[cfg(target_arch = "aarch64")]
 pub use aarch64::*;
+use std::cmp::max;
+use std::mem::size_of;
 
 /// Errors specific to boot protocol configuration.
 #[derive(Debug, PartialEq)]
@@ -43,6 +45,13 @@ pub enum Error {
     /// Errors specific to device tree boot configuration.
     #[cfg(target_arch = "aarch64")]
     Fdt(fdt::Error),
+
+    /// Boot parameter was specified without its starting address in guest memory.
+    MissingStartAddress,
+    /// Boot parameter address overflows.
+    Overflow,
+    /// Boot parameter address precedes the starting address.
+    InvalidAddress,
 }
 
 impl StdError for Error {
@@ -55,6 +64,12 @@ impl StdError for Error {
             Pvh(ref e) => e.description(),
             #[cfg(target_arch = "aarch64")]
             Fdt(ref e) => e.description(),
+
+            MissingStartAddress => {
+                "Boot parameter was specified without its starting address in guest memory."
+            }
+            Overflow => "Boot parameter address overflows.",
+            InvalidAddress => "Boot parameter address precedes the starting address.",
         }
     }
 }
@@ -103,11 +118,17 @@ pub trait BootConfigurator {
 #[derive(Clone)]
 pub struct BootParams {
     /// "Header section", always written in guest memory irrespective of boot protocol.
-    pub header: (Vec<u8>, GuestAddress),
+    pub header: Vec<u8>,
+    /// Header section address.
+    pub header_start: GuestAddress,
     /// Optional sections containing boot configurations (e.g. E820 map).
-    pub sections: Option<(Vec<u8>, GuestAddress)>,
+    pub sections: Option<Vec<u8>>,
+    /// Sections starting address.
+    pub sections_start: Option<GuestAddress>,
     /// Optional modules specified at boot configuration time.
-    pub modules: Option<(Vec<u8>, GuestAddress)>,
+    pub modules: Option<Vec<u8>>,
+    /// Modules starting address.
+    pub modules_start: Option<GuestAddress>,
 }
 
 impl BootParams {
@@ -118,16 +139,30 @@ impl BootParams {
     /// * `header` - [`ByteValued`] representation of mandatory boot parameters.
     /// * `header_addr` - address in guest memory where `header` will be written.
     ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use linux_loader::configurator::BootParams;
+    /// # use vm_memory::{GuestAddress, ByteValued};
+    /// # #[derive(Clone, Copy, Default)]
+    /// # struct Header;
+    /// # unsafe impl ByteValued for Header {}
+    /// let boot_params = BootParams::new(&Header::default(), GuestAddress(0x1000));
+    /// ```
+    ///
     /// [`ByteValued`]: https://docs.rs/vm-memory/latest/vm_memory/bytes/trait.ByteValued.html
     pub fn new<T: ByteValued>(header: &T, header_addr: GuestAddress) -> Self {
         BootParams {
-            header: (header.as_slice().to_vec(), header_addr),
+            header: header.as_slice().to_vec(),
+            header_start: header_addr,
             sections: None,
+            sections_start: None,
             modules: None,
+            modules_start: None,
         }
     }
 
-    /// Adds or overwrites the boot sections and associated memory address.
+    /// Sets or overwrites the boot sections and associated memory address.
     ///
     /// Unused on `aarch64` and for the Linux boot protocol.
     /// For the PVH boot protocol, the sections specify the memory map table in
@@ -138,19 +173,105 @@ impl BootParams {
     /// * `sections` - vector of [`ByteValued`] boot configurations.
     /// * `sections_addr` - address where the sections will be written in guest memory.
     ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use linux_loader::configurator::BootParams;
+    /// # use vm_memory::{ByteValued, GuestAddress};
+    /// # #[derive(Clone, Copy, Default)]
+    /// # struct Header;
+    /// # unsafe impl ByteValued for Header {}
+    /// # #[derive(Clone, Copy, Default)]
+    /// # struct Section;
+    /// # unsafe impl ByteValued for Section {}
+    /// let mut boot_params = BootParams::new(&Header::default(), GuestAddress(0x1000));
+    /// let mut sections: Vec<Section> = vec![Section::default()];
+    /// boot_params.set_sections(sections.as_slice(), GuestAddress(0x2000));
+    /// // Another call overwrites the sections.
+    /// sections.clear();
+    /// boot_params.set_sections(sections.as_slice(), GuestAddress(0x3000));
+    /// assert_eq!(boot_params.sections.unwrap().len(), 0);
+    /// assert_eq!(boot_params.sections_start.unwrap(), GuestAddress(0x3000));
+    /// ```
+    ///
     /// [`ByteValued`]: https://docs.rs/vm-memory/latest/vm_memory/bytes/trait.ByteValued.html
     /// [`hvm_memmap_table_entry`]: ../loader/elf/start_info/struct.hvm_memmap_table_entry.html
-    pub fn add_sections<T: ByteValued>(&mut self, sections: &[T], sections_addr: GuestAddress) {
-        self.sections = Some((
+    pub fn set_sections<T: ByteValued>(&mut self, sections: &[T], sections_addr: GuestAddress) {
+        self.sections = Some(
             sections
                 .iter()
                 .flat_map(|section| section.as_slice().to_vec())
                 .collect(),
-            sections_addr,
-        ));
+        );
+        self.sections_start = Some(sections_addr);
     }
 
-    /// Adds or overwrites the boot modules and associated memory address.
+    /// Adds a boot section at the specified address (if specified and valid), or appends it.
+    ///
+    /// It's up to the caller to ensure that the section will not overlap with existing content
+    /// or leave a gap past the current sections in the list.
+    ///
+    /// # Arguments
+    ///
+    /// * `section` - [`ByteValued`] boot section element.
+    /// * `section_addr` - optional address for the section in guest memory.
+    ///
+    /// # Returns
+    ///
+    /// Starting address of the section in guest memory, or an error.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use linux_loader::configurator::BootParams;
+    /// # use vm_memory::{Address, GuestAddress, ByteValued};
+    /// # use std::mem::size_of;
+    /// # #[derive(Clone, Copy, Default)]
+    /// # struct Header;
+    /// # unsafe impl ByteValued for Header {}
+    /// # #[derive(Clone, Copy, Default)]
+    /// # struct Section;
+    /// # unsafe impl ByteValued for Section {}
+    /// let mut boot_params = BootParams::new(&Header::default(), GuestAddress(0x1000));
+    /// let section = Section::default();
+    /// // Sections start address needs to be configured first.
+    /// assert!(boot_params.add_section::<Section>(&section, None).is_err());
+    /// let sections_start = GuestAddress(0x2000);
+    /// assert!(boot_params.add_section::<Section>(
+    ///     &section, Some(sections_start)
+    /// ).is_ok());
+    /// // It can be overwritten...
+    /// assert_eq!(boot_params.add_section::<Section>(
+    ///     &section,
+    ///     Some(sections_start)
+    /// ).unwrap(), sections_start);
+    /// // But only if the address is valid.
+    /// assert!(boot_params.add_section::<Section>(
+    ///     &section,
+    ///     Some(sections_start.unchecked_sub(0x100))
+    /// ).is_err());
+    /// // Or appended...
+    /// assert_eq!(
+    ///     boot_params.add_section::<Section>(&section, None).unwrap(),
+    ///     sections_start.unchecked_add(size_of::<Section>() as u64)
+    /// );
+    /// ```
+    ///
+    /// [`ByteValued`]: https://docs.rs/vm-memory/latest/vm_memory/bytes/trait.ByteValued.html
+    pub fn add_section<T: ByteValued>(
+        &mut self,
+        section: &T,
+        section_addr: Option<GuestAddress>,
+    ) -> Result<GuestAddress> {
+        Self::add_boot_parameter_to_list(
+            section,
+            section_addr,
+            &mut self.sections.get_or_insert(vec![]),
+            &mut self.sections_start,
+        )
+    }
+
+    /// Sets or overwrites the boot modules and associated memory address.
     ///
     /// Unused on `aarch64` and for the Linux boot protocol.
     /// For the PVH boot protocol, the modules are specified in [`hvm_modlist_entry`] structs.
@@ -160,22 +281,170 @@ impl BootParams {
     /// * `modules` - vector of [`ByteValued`] boot configurations.
     /// * `modules_addr` - address where the modules will be written in guest memory.
     ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use linux_loader::configurator::BootParams;
+    /// # #[derive(Clone, Copy, Default)]
+    /// # struct Header;
+    /// # unsafe impl ByteValued for Header {}
+    /// # #[derive(Clone, Copy, Default)]
+    /// # struct Module;
+    /// # unsafe impl ByteValued for Module {}
+    /// # use vm_memory::{GuestAddress, ByteValued};
+    /// let mut boot_params = BootParams::new(&Header::default(), GuestAddress(0x1000));
+    /// let mut modules: Vec<Module> = vec![Module::default()];
+    /// boot_params.set_modules(modules.as_slice(), GuestAddress(0x2000));
+    /// // Another call overwrites the sections.
+    /// modules.clear();
+    /// boot_params.set_modules(modules.as_slice(), GuestAddress(0x3000));
+    /// assert_eq!(boot_params.modules.unwrap().len(), 0);
+    /// assert_eq!(boot_params.modules_start.unwrap(), GuestAddress(0x3000));
+    /// ```
+    ///
     /// [`ByteValued`]: https://docs.rs/vm-memory/latest/vm_memory/bytes/trait.ByteValued.html
     /// [`hvm_modlist_entry`]: ../loader/elf/start_info/struct.hvm_modlist_entry.html
-    pub fn add_modules<T: ByteValued>(&mut self, modules: &[T], modules_addr: GuestAddress) {
-        self.modules = Some((
+    pub fn set_modules<T: ByteValued>(&mut self, modules: &[T], modules_addr: GuestAddress) {
+        self.modules = Some(
             modules
                 .iter()
                 .flat_map(|module| module.as_slice().to_vec())
                 .collect(),
-            modules_addr,
-        ));
+        );
+        self.modules_start = Some(modules_addr);
+    }
+
+    /// Adds a boot module at the specified address (if specified and valid), or appends it.
+    ///
+    /// It's up to the caller to ensure that the module will not overlap with existing content
+    /// or leave a gap past the current modules in the list.
+    ///
+    /// # Arguments
+    ///
+    /// * `module` - [`ByteValued`] boot module element.
+    /// * `module_addr` - optional address for the module in guest memory.
+    ///
+    /// # Returns
+    ///
+    /// Starting address of the module in guest memory, or an error.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use linux_loader::configurator::BootParams;
+    /// # use vm_memory::{Address, GuestAddress, ByteValued};
+    /// # use std::mem::size_of;
+    /// # #[derive(Clone, Copy, Default)]
+    /// # struct Header;
+    /// # unsafe impl ByteValued for Header {}
+    /// # #[derive(Clone, Copy, Default)]
+    /// # struct Module;
+    /// # unsafe impl ByteValued for Module {}
+    /// let mut boot_params = BootParams::new(&Header::default(), GuestAddress(0x1000));
+    /// let module = Module::default();
+    /// // Modules start address needs to be configured first.
+    /// assert!(boot_params.add_module::<Module>(&module, None).is_err());
+    /// let modules_start = GuestAddress(0x2000);
+    /// assert!(boot_params.add_module::<Module>(
+    ///     &module, Some(modules_start)
+    /// ).is_ok());
+    /// // It can be overwritten...
+    /// assert_eq!(boot_params.add_module::<Module>(
+    ///     &module,
+    ///     Some(modules_start)
+    /// ).unwrap(), modules_start);
+    /// // But only if the address is valid.
+    /// assert!(boot_params.add_module::<Module>(
+    ///     &module,
+    ///     Some(modules_start.unchecked_sub(0x100))
+    /// ).is_err());
+    /// // Or appended...
+    /// assert_eq!(
+    ///     boot_params.add_module::<Module>(&module, None).unwrap(),
+    ///     modules_start.unchecked_add(size_of::<Module>() as u64)
+    /// );
+    /// ```
+    ///
+    /// [`ByteValued`]: https://docs.rs/vm-memory/latest/vm_memory/bytes/trait.ByteValued.html
+    pub fn add_module<T: ByteValued>(
+        &mut self,
+        module: &T,
+        module_addr: Option<GuestAddress>,
+    ) -> Result<GuestAddress> {
+        Self::add_boot_parameter_to_list(
+            module,
+            module_addr,
+            &mut self.modules.get_or_insert(vec![]),
+            &mut self.modules_start,
+        )
+    }
+
+    /// Adds a boot parameter (section or module) to a byte buffer.
+    ///
+    /// Initializes the buffer and corresponding starting address, if necessary.
+    fn add_boot_parameter_to_list<T: ByteValued>(
+        elem: &T,
+        elem_start_opt: Option<GuestAddress>,
+        bytes_acc: &mut Vec<u8>,
+        list_start_opt: &mut Option<GuestAddress>,
+    ) -> Result<GuestAddress> {
+        if list_start_opt.is_none() {
+            *list_start_opt = elem_start_opt;
+        }
+        let list_start = list_start_opt.ok_or(Error::MissingStartAddress)?;
+        let elem_start = elem_start_opt.unwrap_or(
+            list_start
+                .checked_add(bytes_acc.len() as u64)
+                .ok_or(Error::Overflow)?,
+        );
+        let elem_off = elem_start
+            .checked_offset_from(list_start)
+            .ok_or(Error::InvalidAddress)? as usize;
+        let elem_end = elem_off + size_of::<T>();
+        bytes_acc.resize(max(elem_end, bytes_acc.len()), 0);
+        bytes_acc.splice(elem_off..elem_end, elem.as_slice().iter().cloned());
+        Ok(elem_start)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[derive(Clone, Copy, Default)]
+    struct Foobar {
+        _foo: [u8; 5],
+    }
+
+    unsafe impl ByteValued for Foobar {}
+
+    #[derive(Clone, Copy, Debug, Default, PartialEq)]
+    struct DummyHeader {
+        _dummy: u64,
+    }
+
+    unsafe impl ByteValued for DummyHeader {}
+
+    #[derive(Clone, Copy, Debug, Default, PartialEq)]
+    struct DummySection {
+        _dummy: u64,
+    }
+
+    unsafe impl ByteValued for DummySection {}
+
+    #[derive(Clone, Copy, Debug, Default, PartialEq)]
+    struct DummyModule {
+        _dummy: u64,
+    }
+
+    unsafe impl ByteValued for DummyModule {}
+
+    #[derive(Clone, Copy, Debug, Default, PartialEq)]
+    struct OtherDummyModule {
+        _dummy: u64,
+    }
+
+    unsafe impl ByteValued for OtherDummyModule {}
 
     #[test]
     fn test_error_messages() {
@@ -221,6 +490,200 @@ mod tests {
         assert_eq!(
             format!("{}", Error::Fdt(fdt::Error::WriteFDTToMemory)),
             "Boot Configurator Error: Error writing FDT in guest memory."
+        );
+
+        assert_eq!(
+            format!("{}", Error::MissingStartAddress),
+            "Boot Configurator Error: \
+             Boot parameter was specified without its starting address in guest memory."
+        );
+        assert_eq!(
+            format!("{}", Error::Overflow),
+            "Boot Configurator Error: Boot parameter address overflows."
+        );
+        assert_eq!(
+            format!("{}", Error::InvalidAddress),
+            "Boot Configurator Error: Boot parameter address precedes the starting address."
+        );
+    }
+
+    #[test]
+    fn test_bootparam_list_addition() {
+        let mut accumulator: Vec<u8> = vec![];
+        let start = GuestAddress(0x1000);
+        let foo = Foobar::default();
+
+        // Error case: start address not specified.
+        assert_eq!(
+            format!(
+                "{:?}",
+                BootParams::add_boot_parameter_to_list(&foo, None, &mut accumulator, &mut None)
+                    .err()
+            ),
+            "Some(MissingStartAddress)"
+        );
+
+        // Success case: start address is set, element address not specified - will be appended.
+        assert_eq!(
+            BootParams::add_boot_parameter_to_list(&foo, None, &mut accumulator, &mut Some(start))
+                .unwrap(),
+            start
+        );
+        assert_eq!(accumulator, foo.as_slice().to_vec());
+
+        // Success case: start address is unset, element address is specified.
+        let mut list_start_opt: Option<GuestAddress> = None;
+        assert_eq!(
+            BootParams::add_boot_parameter_to_list(
+                &foo,
+                Some(start),
+                &mut accumulator,
+                &mut list_start_opt
+            )
+            .unwrap(),
+            start
+        );
+        assert_eq!(list_start_opt, Some(start));
+        assert_eq!(accumulator, foo.as_slice().to_vec());
+
+        // Error case: start address is set, element address is specified, but precedes start.
+        assert_eq!(
+            format!(
+                "{:?}",
+                BootParams::add_boot_parameter_to_list(
+                    &foo,
+                    Some(start.unchecked_sub(0x100)),
+                    &mut accumulator,
+                    &mut list_start_opt
+                )
+                .err()
+            ),
+            "Some(InvalidAddress)"
+        );
+
+        // Success case: start address is set, element address is specified and valid.
+
+        // Case 1: element falls in the middle of the accumulator.
+        accumulator.clear();
+        // Start by adding 2 elements.
+        assert!(BootParams::add_boot_parameter_to_list(
+            &foo,
+            None,
+            &mut accumulator,
+            &mut list_start_opt
+        )
+        .is_ok());
+        assert!(BootParams::add_boot_parameter_to_list(
+            &Foobar {
+                _foo: [2, 2, 2, 3, 3]
+            },
+            None,
+            &mut accumulator,
+            &mut list_start_opt
+        )
+        .is_ok());
+        // Sanity check.
+        #[rustfmt::skip]
+        assert_eq!(
+            accumulator,
+            &[
+                0, 0, 0, 0, 0,  // elem 0
+                2, 2, 2, 3, 3,  // elem 1
+            ]
+        );
+
+        // Add a 3rd one that overlaps with the middle of element 1.
+        assert!(BootParams::add_boot_parameter_to_list(
+            &Foobar { _foo: [1u8; 5] },
+            Some(start.unchecked_add(size_of::<Foobar>() as u64 + 3)),
+            &mut accumulator,
+            &mut list_start_opt
+        )
+        .is_ok());
+        #[rustfmt::skip]
+        assert_eq!(
+            accumulator,
+            &[
+                0, 0, 0, 0, 0,              // elem 0
+                2, 2, 2,                    // elem 1 cut short
+                1, 1, 1, 1, 1,              // elem 2
+            ]
+        );
+        assert_eq!(accumulator.len(), 13)
+    }
+
+    #[test]
+    fn test_bootparams() {
+        // Test building bootparams from header.
+        let hdr = DummyHeader::default();
+        let hdr_addr = GuestAddress(0x1000);
+        let mut bootparams = BootParams::new(&hdr, hdr_addr);
+        assert_eq!(bootparams.header, hdr.as_slice());
+        assert_eq!(bootparams.header_start, hdr_addr);
+
+        // Test setting sections.
+        let sections = vec![DummySection::default(); 2];
+        let sections_addr = GuestAddress(0x2000);
+        bootparams.set_sections::<DummySection>(sections.as_slice(), sections_addr);
+        assert_eq!(
+            bootparams.sections,
+            Some(vec![0u8; 2 * size_of::<DummySection>()])
+        );
+        assert_eq!(bootparams.sections_start, Some(sections_addr));
+
+        // Test overwriting sections.
+        let sections = vec![DummySection::default(); 3];
+        let sections_addr = GuestAddress(0x3000);
+        bootparams.set_sections::<DummySection>(sections.as_slice(), sections_addr);
+        assert_eq!(
+            bootparams.sections,
+            Some(vec![0u8; 3 * size_of::<DummySection>()])
+        );
+        assert_eq!(bootparams.sections_start, Some(sections_addr));
+
+        // Test appending a new section.
+        assert_eq!(
+            bootparams.add_section::<DummySection>(&DummySection::default(), None),
+            Ok(sections_addr.unchecked_add(3 * size_of::<DummySection>() as u64))
+        );
+        assert_eq!(
+            bootparams.sections,
+            Some(vec![0u8; 4 * size_of::<DummySection>()])
+        );
+        assert_eq!(bootparams.sections_start, Some(sections_addr));
+
+        // Test setting modules.
+        let modules = vec![DummyModule::default(); 2];
+        let modules_addr = GuestAddress(0x4000);
+        bootparams.set_modules::<DummyModule>(modules.as_slice(), modules_addr);
+        assert_eq!(
+            bootparams.modules,
+            Some(vec![0u8; 2 * size_of::<DummyModule>()])
+        );
+        assert_eq!(bootparams.modules_start, Some(modules_addr));
+
+        // Test overwriting modules.
+        let modules = vec![DummyModule::default(); 3];
+        let modules_addr = GuestAddress(0x5000);
+        bootparams.set_modules::<DummyModule>(modules.as_slice(), modules_addr);
+        assert_eq!(
+            bootparams.modules,
+            Some(vec![0u8; 3 * size_of::<DummyModule>()])
+        );
+        assert_eq!(bootparams.modules_start, Some(modules_addr));
+
+        // Test appending a new module.
+        assert_eq!(
+            bootparams.add_module::<DummyModule>(&DummyModule::default(), None),
+            Ok(modules_addr.unchecked_add(3 * size_of::<DummyModule>() as u64))
+        );
+
+        // Test appending a new module of a different type.
+        assert_eq!(
+            bootparams.add_module::<OtherDummyModule>(&OtherDummyModule::default(), None),
+            Ok(modules_addr.unchecked_add(
+                3 * size_of::<DummyModule>() as u64 + size_of::<OtherDummyModule>() as u64
+            ))
         );
     }
 }

--- a/src/configurator/x86_64/linux.rs
+++ b/src/configurator/x86_64/linux.rs
@@ -1,0 +1,153 @@
+// Copyright © 2020, Oracle and/or its affiliates.
+//
+// Copyright (c) 2019 Intel Corporation. All rights reserved.
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE-BSD-3-Clause file.
+//
+// SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
+
+//! Traits and structs for configuring and loading boot parameters on `x86_64` using the Linux
+//! boot protocol.
+
+use vm_memory::{ByteValued, Bytes, GuestAddress, GuestMemory};
+
+use super::super::{BootConfigurator, Error as BootConfiguratorError, Result};
+use crate::loader::bootparam::boot_params;
+
+use std::error::Error as StdError;
+use std::fmt;
+use std::mem;
+
+/// Boot configurator for the Linux boot protocol.
+pub struct LinuxBootConfigurator {}
+
+/// Errors specific to the Linux boot protocol configuration.
+#[derive(Debug, PartialEq)]
+pub enum Error {
+    /// The zero page extends past the end of guest memory.
+    ZeroPagePastRamEnd,
+    /// Error writing to the zero page of guest memory.
+    ZeroPageSetup,
+}
+
+impl StdError for Error {
+    fn description(&self) -> &str {
+        use Error::*;
+        match self {
+            ZeroPagePastRamEnd => "The zero page extends past the end of guest memory.",
+            ZeroPageSetup => "Error writing to the zero page of guest memory.",
+        }
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "Linux Boot Configurator Error: {}",
+            StdError::description(self)
+        )
+    }
+}
+
+impl From<Error> for BootConfiguratorError {
+    fn from(err: Error) -> Self {
+        BootConfiguratorError::Linux(err)
+    }
+}
+
+impl BootConfigurator for LinuxBootConfigurator {
+    /// Writes the boot parameters (configured elsewhere) into guest memory.
+    ///
+    /// # Arguments
+    ///
+    /// * `header` - boot parameters encapsulated in a [`boot_params`] struct.
+    /// * `sections` - unused.
+    /// * `guest_memory` - guest's physical memory.
+    ///
+    /// [`boot_params`]: ../loader/bootparam/struct.boot_e820_entry.html
+    fn write_bootparams<T, S, M>(
+        header: (T, GuestAddress),
+        _sections: Option<(Vec<S>, GuestAddress)>,
+        guest_memory: &M,
+    ) -> Result<()>
+    where
+        T: ByteValued,
+        S: ByteValued,
+        M: GuestMemory,
+    {
+        // The VMM has filled a `boot_params` struct and its e820 map.
+        // This will be written in guest memory at the zero page.
+        guest_memory
+            .checked_offset(header.1, mem::size_of::<boot_params>())
+            .ok_or(Error::ZeroPagePastRamEnd)?;
+        guest_memory
+            .write_obj(header.0, header.1)
+            .map_err(|_| Error::ZeroPageSetup)?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::mem;
+    use vm_memory::{Address, GuestAddress, GuestMemoryMmap};
+
+    const KERNEL_BOOT_FLAG_MAGIC: u16 = 0xaa55;
+    const KERNEL_HDR_MAGIC: u32 = 0x53726448;
+    const KERNEL_LOADER_OTHER: u8 = 0xff;
+    const KERNEL_MIN_ALIGNMENT_BYTES: u32 = 0x1000000;
+    const MEM_SIZE: u64 = 0x1000000;
+
+    fn create_guest_mem() -> GuestMemoryMmap {
+        GuestMemoryMmap::from_ranges(&[(GuestAddress(0x0), (MEM_SIZE as usize))]).unwrap()
+    }
+
+    fn build_bootparams_common() -> boot_params {
+        let mut params = boot_params::default();
+        params.hdr.boot_flag = KERNEL_BOOT_FLAG_MAGIC;
+        params.hdr.header = KERNEL_HDR_MAGIC;
+        params.hdr.kernel_alignment = KERNEL_MIN_ALIGNMENT_BYTES;
+        params.hdr.type_of_loader = KERNEL_LOADER_OTHER;
+        params
+    }
+
+    #[test]
+    fn test_configure_linux_boot() {
+        let zero_page_addr = GuestAddress(0x30000);
+
+        let params = build_bootparams_common();
+        // This is where we'd append e820 entries, cmdline, PCI, ACPI etc.
+
+        let guest_memory = create_guest_mem();
+
+        // Error case: boot params don't fit in guest memory (zero page address too close to end).
+        let bad_zeropg_addr = GuestAddress(
+            guest_memory.last_addr().raw_value() - mem::size_of::<boot_params>() as u64 + 1,
+        );
+        assert_eq!(
+            LinuxBootConfigurator::write_bootparams::<boot_params, boot_params, GuestMemoryMmap>(
+                (params, bad_zeropg_addr),
+                None,
+                &guest_memory,
+            )
+            .err(),
+            Some(Error::ZeroPagePastRamEnd.into()),
+        );
+
+        // Success case.
+        assert!(
+            LinuxBootConfigurator::write_bootparams::<boot_params, boot_params, GuestMemoryMmap>(
+                (params, zero_page_addr),
+                None,
+                &guest_memory
+            )
+            .is_ok()
+        );
+    }
+}

--- a/src/configurator/x86_64/linux.rs
+++ b/src/configurator/x86_64/linux.rs
@@ -74,10 +74,10 @@ impl BootConfigurator for LinuxBootConfigurator {
         // The VMM has filled a `boot_params` struct and its e820 map.
         // This will be written in guest memory at the zero page.
         guest_memory
-            .checked_offset(params.header.1, params.header.0.len())
+            .checked_offset(params.header_start, params.header.len())
             .ok_or(Error::ZeroPagePastRamEnd)?;
         guest_memory
-            .write_slice(params.header.0.as_slice(), params.header.1)
+            .write_slice(params.header.as_slice(), params.header_start)
             .map_err(|_| Error::ZeroPageSetup)?;
 
         Ok(())
@@ -134,7 +134,7 @@ mod tests {
         );
 
         // Success case.
-        bootparams.header.1 = zero_page_addr;
+        bootparams.header_start = zero_page_addr;
         assert!(LinuxBootConfigurator::write_bootparams::<GuestMemoryMmap>(
             bootparams,
             &guest_memory,

--- a/src/configurator/x86_64/mod.rs
+++ b/src/configurator/x86_64/mod.rs
@@ -1,0 +1,17 @@
+// Copyright © 2020, Oracle and/or its affiliates.
+//
+// Copyright (c) 2019 Intel Corporation. All rights reserved.
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE-BSD-3-Clause file.
+//
+// SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
+
+//! Traits and structs for configuring and loading boot parameters on `x86_64`.
+
+#![cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+
+pub mod linux;
+pub mod pvh;

--- a/src/configurator/x86_64/pvh.rs
+++ b/src/configurator/x86_64/pvh.rs
@@ -1,0 +1,238 @@
+// Copyright © 2020, Oracle and/or its affiliates.
+//
+// Copyright (c) 2019 Intel Corporation. All rights reserved.
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE-BSD-3-Clause file.
+//
+// SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
+
+//! Traits and structs for configuring and loading boot parameters on `x86_64` using the PVH boot
+//! protocol.
+
+use vm_memory::{Address, ByteValued, Bytes, GuestAddress, GuestMemory};
+
+use super::super::{BootConfigurator, Error as BootConfiguratorError, Result};
+use crate::loader::elf::start_info::{hvm_memmap_table_entry, hvm_start_info};
+
+use std::error::Error as StdError;
+use std::fmt;
+use std::mem;
+
+/// Boot configurator for the PVH boot protocol.
+pub struct PvhBootConfigurator {}
+
+/// Errors specific to the PVH boot protocol configuration.
+#[derive(Debug, PartialEq)]
+pub enum Error {
+    /// No memory map wasn't passed to the boot configurator.
+    MemmapTableMissing,
+    /// The memory map table extends past the end of guest memory.
+    MemmapTablePastRamEnd,
+    /// Error writing memory map table to guest memory.
+    MemmapTableSetup,
+    /// The hvm_start_info structure extends past the end of guest memory.
+    StartInfoPastRamEnd,
+    /// Error writing hvm_start_info to guest memory.
+    StartInfoSetup,
+}
+
+impl StdError for Error {
+    fn description(&self) -> &str {
+        use Error::*;
+        match self {
+            MemmapTableMissing => "No memory map wasn't passed to the boot configurator.",
+            MemmapTablePastRamEnd => "The memory map table extends past the end of guest memory.",
+            MemmapTableSetup => "Error writing memory map table to guest memory.",
+            StartInfoPastRamEnd => {
+                "The hvm_start_info structure extends past the end of guest memory."
+            }
+            StartInfoSetup => "Error writing hvm_start_info to guest memory.",
+        }
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "PVH Boot Configurator Error: {}",
+            StdError::description(self)
+        )
+    }
+}
+
+impl From<Error> for BootConfiguratorError {
+    fn from(err: Error) -> Self {
+        BootConfiguratorError::Pvh(err)
+    }
+}
+
+unsafe impl ByteValued for hvm_start_info {}
+unsafe impl ByteValued for hvm_memmap_table_entry {}
+
+impl BootConfigurator for PvhBootConfigurator {
+    /// Writes the boot parameters (configured elsewhere) into guest memory.
+    ///
+    /// # Arguments
+    ///
+    /// * `header` - boot parameters encapsulated in a [`hvm_start_info`] struct.
+    /// * `sections` - memory map table represented as a vector of [`hvm_memmap_table_entry`].
+    /// * `guest_memory` - guest's physical memory.
+    ///
+    /// [`hvm_start_info`]: ../loader/elf/start_info/struct.hvm_start_info
+    /// [`hvm_memmap_table_entry`]: ../loader/elf/start_info/struct.hvm_memmap_table_entry.html
+    fn write_bootparams<T, S, M>(
+        header: (T, GuestAddress),
+        sections: Option<(Vec<S>, GuestAddress)>,
+        guest_memory: &M,
+    ) -> Result<()>
+    where
+        T: ByteValued,
+        S: ByteValued,
+        M: GuestMemory,
+    {
+        // The VMM has filled an `hvm_start_info` struct and a `Vec<hvm_memmap_table_entry>`
+        // and has passed them on to this function.
+        // The `hvm_start_info` will be written at `addr` and the memmap entries at
+        // `start_info.0.memmap_paddr`.
+        let (memmap_entries, mut memmap_start_addr) = sections.ok_or(Error::MemmapTableMissing)?;
+        guest_memory
+            .checked_offset(
+                memmap_start_addr,
+                mem::size_of::<hvm_memmap_table_entry>() * memmap_entries.len(),
+            )
+            .ok_or(Error::MemmapTablePastRamEnd)?;
+
+        for memmap_entry in memmap_entries {
+            guest_memory
+                .write_obj(memmap_entry, memmap_start_addr)
+                .map_err(|_| Error::MemmapTableSetup)?;
+            memmap_start_addr =
+                memmap_start_addr.unchecked_add(mem::size_of::<hvm_memmap_table_entry>() as u64);
+        }
+
+        guest_memory
+            .checked_offset(header.1, mem::size_of::<hvm_start_info>())
+            .ok_or(Error::StartInfoPastRamEnd)?;
+        guest_memory
+            .write_obj(header.0, header.1)
+            .map_err(|_| Error::StartInfoSetup)?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vm_memory::{Address, GuestAddress, GuestMemoryMmap};
+
+    const XEN_HVM_START_MAGIC_VALUE: u32 = 0x336ec578;
+    const MEM_SIZE: u64 = 0x1000000;
+    const E820_RAM: u32 = 1;
+
+    fn create_guest_mem() -> GuestMemoryMmap {
+        GuestMemoryMmap::from_ranges(&[(GuestAddress(0x0), (MEM_SIZE as usize))]).unwrap()
+    }
+
+    fn add_memmap_entry(
+        memmap_entries: &mut Vec<hvm_memmap_table_entry>,
+        addr: GuestAddress,
+        size: u64,
+        mem_type: u32,
+    ) {
+        // Add the table entry to the vector
+        memmap_entries.push(hvm_memmap_table_entry {
+            addr: addr.raw_value(),
+            size,
+            type_: mem_type,
+            reserved: 0,
+        });
+    }
+
+    fn build_bootparams_common() -> (hvm_start_info, Vec<hvm_memmap_table_entry>) {
+        let mut start_info = hvm_start_info::default();
+        let memmap_entries: Vec<hvm_memmap_table_entry> = vec![];
+
+        start_info.magic = XEN_HVM_START_MAGIC_VALUE;
+        start_info.version = 1;
+        start_info.nr_modules = 0;
+        start_info.memmap_entries = 0;
+
+        (start_info, memmap_entries)
+    }
+
+    #[test]
+    fn test_configure_pvh_boot() {
+        let (mut start_info, mut memmap_entries) = build_bootparams_common();
+        let guest_memory = create_guest_mem();
+
+        let start_info_addr = GuestAddress(0x6000);
+        let memmap_addr = GuestAddress(0x7000);
+        start_info.memmap_paddr = memmap_addr.raw_value();
+
+        // Error case: configure without memory map.
+        assert_eq!(
+            PvhBootConfigurator::write_bootparams::<
+                hvm_start_info,
+                hvm_memmap_table_entry,
+                GuestMemoryMmap,
+            >((start_info, start_info_addr), None, &guest_memory,)
+            .err(),
+            Some(Error::MemmapTableMissing.into())
+        );
+
+        // Error case: start_info doesn't fit in guest memory.
+        let bad_start_info_addr = GuestAddress(
+            guest_memory.last_addr().raw_value() - mem::size_of::<hvm_start_info>() as u64 + 1,
+        );
+        assert_eq!(
+            PvhBootConfigurator::write_bootparams::<
+                hvm_start_info,
+                hvm_memmap_table_entry,
+                GuestMemoryMmap,
+            >(
+                (start_info, bad_start_info_addr),
+                Some((memmap_entries.clone(), memmap_addr)),
+                &guest_memory,
+            )
+            .err(),
+            Some(Error::StartInfoPastRamEnd.into())
+        );
+
+        // Error case: memory map doesn't fit in guest memory.
+        let himem_start = GuestAddress(0x100000);
+        add_memmap_entry(&mut memmap_entries, himem_start, 0, E820_RAM);
+        let bad_memmap_addr = GuestAddress(
+            guest_memory.last_addr().raw_value() - mem::size_of::<hvm_memmap_table_entry>() as u64
+                + 1,
+        );
+        assert_eq!(
+            PvhBootConfigurator::write_bootparams::<
+                hvm_start_info,
+                hvm_memmap_table_entry,
+                GuestMemoryMmap,
+            >(
+                (start_info, start_info_addr),
+                Some((memmap_entries.clone(), bad_memmap_addr)),
+                &guest_memory,
+            )
+            .err(),
+            Some(Error::MemmapTablePastRamEnd.into())
+        );
+
+        assert!(PvhBootConfigurator::write_bootparams::<
+            hvm_start_info,
+            hvm_memmap_table_entry,
+            GuestMemoryMmap,
+        >(
+            (start_info, start_info_addr),
+            Some((memmap_entries.clone(), memmap_addr)),
+            &guest_memory,
+        )
+        .is_ok());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@
 //!
 
 pub mod cmdline;
+pub mod configurator;
 pub mod loader;
 
 extern crate vm_memory;

--- a/src/loader/aarch64/pe/mod.rs
+++ b/src/loader/aarch64/pe/mod.rs
@@ -195,7 +195,7 @@ mod tests {
     use std::io::Cursor;
     use vm_memory::{Address, GuestAddress, GuestMemoryMmap};
 
-    const MEM_SIZE: u64 = 0x1000000;
+    const MEM_SIZE: u64 = 0x100_0000;
 
     fn create_guest_mem() -> GuestMemoryMmap {
         GuestMemoryMmap::from_ranges(&[(GuestAddress(0x0), (MEM_SIZE as usize))]).unwrap()

--- a/src/loader/mod.rs
+++ b/src/loader/mod.rs
@@ -157,6 +157,7 @@ pub trait KernelLoader {
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 unsafe impl ByteValued for bootparam::setup_header {}
+unsafe impl ByteValued for bootparam::boot_params {}
 
 /// Writes the command line string to the given guest memory slice.
 ///

--- a/src/loader/mod.rs
+++ b/src/loader/mod.rs
@@ -157,6 +157,7 @@ pub trait KernelLoader {
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 unsafe impl ByteValued for bootparam::setup_header {}
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 unsafe impl ByteValued for bootparam::boot_params {}
 
 /// Writes the command line string to the given guest memory slice.
@@ -195,7 +196,7 @@ mod tests {
     use super::*;
     use vm_memory::{Address, GuestAddress, GuestMemoryMmap};
 
-    const MEM_SIZE: u64 = 0x1000000;
+    const MEM_SIZE: u64 = 0x100_0000;
 
     fn create_guest_mem() -> GuestMemoryMmap {
         GuestMemoryMmap::from_ranges(&[(GuestAddress(0x0), (MEM_SIZE as usize))]).unwrap()

--- a/src/loader/x86_64/bzimage/mod.rs
+++ b/src/loader/x86_64/bzimage/mod.rs
@@ -179,7 +179,7 @@ mod tests {
     use std::io::Cursor;
     use vm_memory::{Address, GuestAddress, GuestMemoryMmap};
 
-    const MEM_SIZE: u64 = 0x1000000;
+    const MEM_SIZE: u64 = 0x100_0000;
 
     fn create_guest_mem() -> GuestMemoryMmap {
         GuestMemoryMmap::from_ranges(&[(GuestAddress(0x0), (MEM_SIZE as usize))]).unwrap()

--- a/src/loader/x86_64/elf/mod.rs
+++ b/src/loader/x86_64/elf/mod.rs
@@ -359,7 +359,7 @@ mod tests {
     use std::io::Cursor;
     use vm_memory::{Address, GuestAddress, GuestMemoryMmap};
 
-    const MEM_SIZE: u64 = 0x1000000;
+    const MEM_SIZE: u64 = 0x100_0000;
 
     fn create_guest_mem() -> GuestMemoryMmap {
         GuestMemoryMmap::from_ranges(&[(GuestAddress(0x0), (MEM_SIZE as usize))]).unwrap()


### PR DESCRIPTION
#15 

This PR introduces a new `configurator` module, meant to build (TBD) and write (included in this PR) boot parameters in guest memory. To begin with, the VMM will have to build its own boot params, encapsulate them into [`ByteValued`](https://docs.rs/vm-memory/0.2.0/vm_memory/bytes/trait.ByteValued.html) objects, then pass them on to `linux-loader`.

VMM workflow:

```rust
let load_result = kernel_loader.load<ReadImpl, GuestMemoryImpl>(
        guest_memory,
        kernel_start_addr,
        kernel_image,
        himem_start_addr
)?;
let (boot_params_header, boot_params_sections): (HeaderImpl, Vec<SectionImpl>) = Vmm::build_boot_params()?;
BootConfiguratorImpl::write_bootparams::<HeaderImpl, SectionImpl, GuestMemoryImpl>(
        (boot_params_header, header_addr),
        Some((boot_params_sections, sections_addr)),
        guest_memory
)?;
```

The PR adds support for 3 boot protocols:

### `x86_64` Linux boot
* `header`:  [`boot_params`](https://github.com/rust-vmm/linux-loader/blob/2adddce25b37f68c99ae8e7db1cb7f5853626fdd/src/loader/bootparam.rs#L3475) struct, everything that goes into the zeropage
* `sections`: unused (e820 map included in `header`)

```rust
let params: boot_params = Vmm::build_boot_params_linux()?;
LinuxBootConfigurator::write_bootparams::<boot_params, boot_params, GuestMemoryImpl>(
        (params, zeropg_addr),
        None,
        guest_memory
)?;
```

### `x86_64` PVH boot
* `header`:  [`hvm_start_info`](https://github.com/rust-vmm/linux-loader/blob/2adddce25b37f68c99ae8e7db1cb7f5853626fdd/src/loader/x86_64/elf/start_info.rs#L126) struct
* `sections`: vector of [`hvm_memmap_table_entry`](https://github.com/rust-vmm/linux-loader/blob/2adddce25b37f68c99ae8e7db1cb7f5853626fdd/src/loader/x86_64/elf/start_info.rs#L150) structs: memory map table entries

```rust
let (start_info, memmap_entries): (hvm_start_info, Vec<hvm_memmap_table_entry>) = Vmm::build_boot_params_pvh()?;
PvhBootConfigurator::write_bootparams::<hvm_start_info, hvm_memmap_table_entry, GuestMemoryImpl>(
        (start_info, start_info_addr),
        Some((memmap_entries, memmap_addr)),
        guest_memory
)?;
```

### `aarch64` boot

* `header`: byte blob containing the compiled FDT
* `sections`: unused

```rust
struct FdtBlob { ... }
impl ByteValued for FdtBlob { ... }
...
let fdt_blob: FdtBlob= Vmm::build_fdt()?;
FdtBootConfigurator::write_bootparams::<FdtBlob, FdtBlob, GuestMemoryImpl>(
        (fdt_blob, fdt_addr),
        None,
        guest_memory
)?;
```