### PR TITLE
Clarify uses of kernel_start parameter

### DIFF
--- a/coverage_config_aarch64.json
+++ b/coverage_config_aarch64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 80.8,
+  "coverage_score": 80.7,
   "exclude_path": "",
   "crate_features": "pe"
 }

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 84.8,
+  "coverage_score": 83.4,
   "exclude_path": "",
   "crate_features": "bzimage,elf",
   "exclude_path": "loader_gen"

--- a/src/loader/aarch64/pe/mod.rs
+++ b/src/loader/aarch64/pe/mod.rs
@@ -1,3 +1,4 @@
+// Copyright © 2020, Oracle and/or its affiliates.
 // Copyright (c) 2019 Intel Corporation. All rights reserved.
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
@@ -48,6 +49,8 @@ pub enum Error {
     InvalidImage,
     /// Invalid Image magic number.
     InvalidImageMagicNumber,
+    /// Invalid base address alignment
+    InvalidBaseAddrAlignment,
 }
 
 impl error::Error for Error {
@@ -63,6 +66,7 @@ impl error::Error for Error {
             Error::InvalidImageMagicNumber => "Invalid Image magic number",
             Error::DtbTooBig => "Device tree image too big",
             Error::ReadKernelImage => "Unable to read kernel image",
+            Error::InvalidBaseAddrAlignment => "Base address not aligned to 2 MB",
         }
     }
 }
@@ -96,7 +100,7 @@ impl KernelLoader for PE {
     /// # Arguments
     ///
     /// * `guest_mem` - The guest memory where the kernel image is loaded.
-    /// * `kernel_offset` - 2MB-aligned base addres in guest memory at at which to load the kernel.
+    /// * `kernel_offset` - 2MB-aligned base addres in guest memory at which to load the kernel.
     /// * `kernel_image` - Input Image format kernel image.
     /// * `highmem_start_address` - ignored on ARM64.
     ///
@@ -133,6 +137,14 @@ impl KernelLoader for PE {
 
         if image_size == 0 {
             text_offset = 0x80000;
+        }
+
+        // Validate that kernel_offset is 2 MB aligned, as required by the
+        // arm64 boot protocol
+        if let Some(kernel_offset) = kernel_offset {
+            if kernel_offset.raw_value() % 0x0020_0000 != 0 {
+                return Err(Error::InvalidBaseAddrAlignment.into());
+            }
         }
 
         let mem_offset = kernel_offset
@@ -217,6 +229,14 @@ mod tests {
             PE::load(&gm, Some(kernel_addr), &mut Cursor::new(&image), None).unwrap();
         assert_eq!(loader_result.kernel_load.raw_value(), 0x280000);
         assert_eq!(loader_result.kernel_end, 0x281000);
+
+        // Attempt to load the kernel at an address that is not aligned to 2MB boundary
+        let kernel_offset = GuestAddress(0x0030_0000);
+        let loader_result = PE::load(&gm, Some(kernel_offset), &mut Cursor::new(&image), None);
+        assert_eq!(
+            loader_result,
+            Err(KernelLoaderError::Pe(Error::InvalidBaseAddrAlignment))
+        );
 
         image[0x39] = 0x0;
         let loader_result = PE::load(&gm, Some(kernel_addr), &mut Cursor::new(&image), None);

--- a/src/loader/aarch64/pe/mod.rs
+++ b/src/loader/aarch64/pe/mod.rs
@@ -96,7 +96,7 @@ impl KernelLoader for PE {
     /// # Arguments
     ///
     /// * `guest_mem` - The guest memory where the kernel image is loaded.
-    /// * `kernel_start` - The offset into 'guest_mem' at which to load the kernel.
+    /// * `kernel_offset` - 2MB-aligned base addres in guest memory at at which to load the kernel.
     /// * `kernel_image` - Input Image format kernel image.
     /// * `highmem_start_address` - ignored on ARM64.
     ///
@@ -104,7 +104,7 @@ impl KernelLoader for PE {
     /// * KernelLoaderResult
     fn load<F, M: GuestMemory>(
         guest_mem: &M,
-        kernel_start: Option<GuestAddress>,
+        kernel_offset: Option<GuestAddress>,
         kernel_image: &mut F,
         _highmem_start_address: Option<GuestAddress>,
     ) -> Result<KernelLoaderResult>
@@ -135,7 +135,7 @@ impl KernelLoader for PE {
             text_offset = 0x80000;
         }
 
-        let mem_offset = kernel_start
+        let mem_offset = kernel_offset
             .unwrap_or(GuestAddress(0))
             .checked_add(text_offset)
             .ok_or(Error::InvalidImage)?;

--- a/src/loader/mod.rs
+++ b/src/loader/mod.rs
@@ -132,10 +132,11 @@ pub struct KernelLoaderResult {
     /// See https://www.kernel.org/doc/Documentation/x86/boot.txt.
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     pub setup_header: Option<bootparam::setup_header>,
-    /// This field optionally holds the address of a PVH entry point, indicating that
-    /// the kernel supports the PVH boot protocol as described in:
+    /// Availability of a PVH entry point. Only used for ELF boot, indicates whether the kernel
+    /// supports the PVH boot protocol as described in:
     /// https://xenbits.xen.org/docs/unstable/misc/pvh.html
-    pub pvh_entry_addr: Option<GuestAddress>,
+    #[cfg(all(feature = "elf", any(target_arch = "x86", target_arch = "x86_64")))]
+    pub pvh_boot_cap: elf::PvhBootCapability,
 }
 
 /// Trait that specifies kernel image loading support.

--- a/src/loader/mod.rs
+++ b/src/loader/mod.rs
@@ -145,14 +145,14 @@ pub trait KernelLoader {
     /// # Arguments
     ///
     /// * `guest_mem`: [`GuestMemory`] to load the kernel in.
-    /// * `kernel_start`: Address in guest memory where the kernel is loaded.
+    /// * `kernel_offset`: Usage varies between implementations.
     /// * `kernel_image`: Kernel image to be loaded.
     /// * `highmem_start_address`: Address where high memory starts.
     ///
     /// [`GuestMemory`]: https://docs.rs/vm-memory/latest/vm_memory/guest_memory/trait.GuestMemory.html
     fn load<F, M: GuestMemory>(
         guest_mem: &M,
-        kernel_start: Option<GuestAddress>,
+        kernel_offset: Option<GuestAddress>,
         kernel_image: &mut F,
         highmem_start_address: Option<GuestAddress>,
     ) -> Result<KernelLoaderResult>


### PR DESCRIPTION
As part of the discussion in #12, we have noticed that the `kernel_start` parameter has different usages in the implementations for `PE`, `Elf`, and `BzImage`. The `Elf` implementation is specially confusing, since `kernel_start` is used to specify an offset to add to the default load address of the kernel. The discussion is ongoing to determine whether this has any real use cases or provides any security benefits.

In the meantime, I propose to rename the parameter to `kernel_offset`, which might be more appropriate to describe its usage by the implementers of `KernelLoader`.

Also, since PVH code expects the kernel to be loaded at its default load address, it cannot be used to boot guests if a non-default load address is requested by using the `kernel_offset` argument. If `kernel_offset` is requested, we simply avoid looking for a PVH entry point.

Resolves #12 