### PR TITLE
Fix some warnings and errors

### DIFF
--- a/.buildkite/hooks/post-checkout
+++ b/.buildkite/hooks/post-checkout
@@ -13,6 +13,6 @@ mkdir -p ${EXTRACT_PATH}
 wget $DEB_URL -P ${REPO_PATH}
 dpkg-deb -x ${DEB_PATH} ${EXTRACT_PATH}
 
-mv ${BZIMAGE_PATH} ${REPO_PATH}/src/loader/x86_64/bzimage/bzimage
+mv ${BZIMAGE_PATH} ${REPO_PATH}/bzImage
 rm -r ${EXTRACT_PATH}
 rm -f ${DEB_PATH}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ bzimage = []
 pe = []
 
 [dependencies]
-vm-memory = ">=0.2.0"
+vm-memory = ">=0.2.1"
 
 [dev-dependencies]
-vm-memory = {features = ["backend-mmap"]}
+vm-memory = { version = ">=0.2.1", features = ["backend-mmap"] }

--- a/coverage_config_aarch64.json
+++ b/coverage_config_aarch64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 80.8,
+  "coverage_score": 80.4,
   "exclude_path": "",
   "crate_features": "pe"
 }

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -8,7 +8,9 @@ For the complete list of tests, check our
 [CI pipeline](https://buildkite.com/rust-vmm/rust-vmm-ci).
 
 Each individual test runs in a container. To reproduce a test locally, you can
-use the dev-container on both x86 and arm64.
+use the dev-container on both x86 and arm64. Please note some features are not
+enabled (and thus not tested) by default. To run tests with all features
+enabled, use `cargo test --all-features`.
 
 ```bash
 container_version=5
@@ -17,22 +19,22 @@ docker run -it \
            --volume $(pwd):/linux-loader \
            rustvmm/dev:v${container_version}
 cd linux-loader/
-cargo test
+cargo test --all-features
 ```
 
 ### bzImage test
 
 As we don't want to distribute an entire kernel bzImage, the `load_bzImage`
 test is ignored by default. In order to test the bzImage support, one needs to
-locally build a bzImage, copy it to the `src/loader` directory and run
-`cargo test`:
+locally build a bzImage and copy it to the current working directory for
+`cargo test --features bzimage`:
 
 ```bash
 # Assuming your linux-loader and linux-stable are both under ${LINUX_LOADER}:
 git clone git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git ${LINUX_LOADER}/linux-stable
 cd linux-stable
 make bzImage
-cp linux-stable/arch/x86/boot/bzImage ${LINUX_LOADER}/linux-loader/src/loader/
+cp linux-stable/arch/x86/boot/bzImage ${LINUX_LOADER}/linux-loader
 cd ${LINUX_LOADER}/linux-loader
 container_version=5
 docker run -it \
@@ -40,5 +42,5 @@ docker run -it \
            --volume $(pwd):/linux-loader \
            rustvmm/dev:v${container_version}
 cd linux-loader/
-cargo test
+cargo test --features bzimage
 ```

--- a/src/configurator/x86_64/linux.rs
+++ b/src/configurator/x86_64/linux.rs
@@ -31,23 +31,16 @@ pub enum Error {
     ZeroPageSetup,
 }
 
-impl StdError for Error {
-    fn description(&self) -> &str {
-        use Error::*;
-        match self {
-            ZeroPagePastRamEnd => "The zero page extends past the end of guest memory.",
-            ZeroPageSetup => "Error writing to the zero page of guest memory.",
-        }
-    }
-}
+impl StdError for Error {}
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "Linux Boot Configurator Error: {}",
-            StdError::description(self)
-        )
+        use Error::*;
+        let msg = match self {
+            ZeroPagePastRamEnd => "The zero page extends past the end of guest memory.",
+            ZeroPageSetup => "Error writing to the zero page of guest memory.",
+        };
+        write!(f, "Linux Boot Configurator Error: {}", msg)
     }
 }
 

--- a/src/configurator/x86_64/pvh.rs
+++ b/src/configurator/x86_64/pvh.rs
@@ -40,10 +40,12 @@ pub enum Error {
     StartInfoSetup,
 }
 
-impl StdError for Error {
-    fn description(&self) -> &str {
+impl StdError for Error {}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use Error::*;
-        match self {
+        let msg = match self {
             MemmapTableAddressMissing => {
                 "The starting address for the memory map wasn't passed to the boot configurator."
             }
@@ -54,17 +56,8 @@ impl StdError for Error {
                 "The hvm_start_info structure extends past the end of guest memory."
             }
             StartInfoSetup => "Error writing hvm_start_info to guest memory.",
-        }
-    }
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "PVH Boot Configurator Error: {}",
-            StdError::description(self)
-        )
+        };
+        write!(f, "PVH Boot Configurator Error: {}", msg)
     }
 }
 

--- a/src/loader/mod.rs
+++ b/src/loader/mod.rs
@@ -71,27 +71,23 @@ pub enum Error {
 /// [`Result`]: https://doc.rust-lang.org/std/result/enum.Result.html
 pub type Result<T> = std::result::Result<T, Error>;
 
-impl StdError for Error {
-    fn description(&self) -> &str {
-        match self {
-            #[cfg(all(feature = "bzimage", any(target_arch = "x86", target_arch = "x86_64")))]
-            Error::Bzimage(ref e) => e.description(),
-            #[cfg(all(feature = "elf", any(target_arch = "x86", target_arch = "x86_64")))]
-            Error::Elf(ref e) => e.description(),
-            #[cfg(all(feature = "pe", target_arch = "aarch64"))]
-            Error::Pe(ref e) => e.description(),
-
-            Error::CommandLineCopy => "Failed writing command line to guest memory",
-            Error::CommandLineOverflow => "Command line overflowed guest memory",
-            Error::InvalidKernelStartAddress => "Invalid kernel start address",
-            Error::MemoryOverflow => "Memory to load kernel image is not enough",
-        }
-    }
-}
+impl StdError for Error {}
 
 impl Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Kernel Loader Error: {}", Error::description(self))
+        write!(f, "Kernel Loader Error: ")?;
+        match self {
+            #[cfg(all(feature = "bzimage", any(target_arch = "x86", target_arch = "x86_64")))]
+            Error::Bzimage(ref e) => write!(f, "{}", e),
+            #[cfg(all(feature = "elf", any(target_arch = "x86", target_arch = "x86_64")))]
+            Error::Elf(ref e) => write!(f, "{}", e),
+            #[cfg(all(feature = "pe", target_arch = "aarch64"))]
+            Error::Pe(ref e) => write!(f, "{}", e),
+            Error::CommandLineCopy => write!(f, "Failed writing command line to guest memory"),
+            Error::CommandLineOverflow => write!(f, "Command line overflowed guest memory"),
+            Error::InvalidKernelStartAddress => write!(f, "Invalid kernel start address"),
+            Error::MemoryOverflow => write!(f, "Memory to load kernel image is not enough"),
+        }
     }
 }
 

--- a/src/loader/x86_64/bzimage/mod.rs
+++ b/src/loader/x86_64/bzimage/mod.rs
@@ -120,12 +120,12 @@ impl KernelLoader for BzImage {
         // If the `HdrS` magic number is not found at offset 0x202, the boot protocol version is
         // "old", the image type is assumed as zImage, not bzImage.
         if boot_header.header != 0x5372_6448 {
-            Err(Error::InvalidBzImage)?;
+            return Err(Error::InvalidBzImage.into());
         }
 
         // Follow the section related to loading the rest of the kernel in the linux boot protocol.
         if (boot_header.version < 0x0200) || ((boot_header.loadflags & 0x1) == 0x0) {
-            Err(Error::InvalidBzImage)?;
+            return Err(Error::InvalidBzImage.into());
         }
 
         let mut setup_size = boot_header.setup_sects as usize;

--- a/src/loader/x86_64/elf/mod.rs
+++ b/src/loader/x86_64/elf/mod.rs
@@ -11,7 +11,7 @@
 
 #![cfg(all(feature = "elf", any(target_arch = "x86", target_arch = "x86_64")))]
 
-use std::error::{self, Error as StdError};
+use std::error;
 use std::fmt::{self, Display};
 use std::io::{Read, Seek, SeekFrom};
 use std::mem;
@@ -61,9 +61,11 @@ pub enum Error {
     InvalidPvhNote,
 }
 
-impl error::Error for Error {
-    fn description(&self) -> &str {
-        match self {
+impl error::Error for Error {}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let msg = match self {
             Error::BigEndianElfOnLittle => {
                 "Trying to load big-endian binary on little-endian machine"
             }
@@ -81,13 +83,8 @@ impl error::Error for Error {
             Error::SeekNoteHeader => "Unable to seek to note header",
             Error::ReadNoteHeader => "Unable to read note header",
             Error::InvalidPvhNote => "Invalid PVH note header",
-        }
-    }
-}
-
-impl Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Kernel Loader Error: {}", self.description())
+        };
+        write!(f, "Kernel Loader Error: {}", msg)
     }
 }
 


### PR DESCRIPTION
This fixes some warnings and errors such as:
- We were implementing the now deprecated `Error::description` for various error types.
- The `Cargo.toml` dev dependency to `vm-memory` did not refer a particular version.
- The `include_bytes!("bzimage")` statement led to a build time error for doc and unit tests when the file did not exist.

Fixes #35 
Related to #36