### PR TITLE
cmdline: implement std::error::Error for Error

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 83.4,
+  "coverage_score": 80.8,
   "exclude_path": "",
   "crate_features": "bzimage,elf",
   "exclude_path": "loader_gen"

--- a/src/cmdline/mod.rs
+++ b/src/cmdline/mod.rs
@@ -39,6 +39,8 @@ impl fmt::Display for Error {
     }
 }
 
+impl std::error::Error for Error {}
+
 /// Specialized [`Result`] type for command line operations.
 ///
 /// [`Result`]: https://doc.rust-lang.org/std/result/enum.Result.html

--- a/src/configurator/aarch64/fdt.rs
+++ b/src/configurator/aarch64/fdt.rs
@@ -6,7 +6,6 @@
 
 use vm_memory::{Bytes, GuestMemory};
 
-use std::error::Error as StdError;
 use std::fmt;
 
 use crate::configurator::{BootConfigurator, BootParams, Error as BootConfiguratorError, Result};
@@ -20,25 +19,19 @@ pub enum Error {
     WriteFDTToMemory,
 }
 
-impl StdError for Error {
-    fn description(&self) -> &str {
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use Error::*;
-        match self {
+        let desc = match self {
             FDTPastRamEnd => "FDT does not fit in guest memory.",
-            WriteFDTToMemory => "Error writing FDT in guest memory.",
-        }
+            WriteFDTToMemory => "error writing FDT in guest memory.",
+        };
+
+        write!(f, "Device Tree Boot Configurator: {}", desc)
     }
 }
 
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "Device Tree Boot Configurator Error: {}",
-            StdError::description(self)
-        )
-    }
-}
+impl std::error::Error for Error {}
 
 impl From<Error> for BootConfiguratorError {
     fn from(err: Error) -> Self {
@@ -142,11 +135,11 @@ mod tests {
     fn test_error_messages() {
         assert_eq!(
             format!("{}", Error::FDTPastRamEnd),
-            "Device Tree Boot Configurator Error: FDT does not fit in guest memory."
+            "Device Tree Boot Configurator: FDT does not fit in guest memory."
         );
         assert_eq!(
             format!("{}", Error::WriteFDTToMemory),
-            "Device Tree Boot Configurator Error: Error writing FDT in guest memory."
+            "Device Tree Boot Configurator: error writing FDT in guest memory."
         );
     }
 }

--- a/src/configurator/x86_64/linux.rs
+++ b/src/configurator/x86_64/linux.rs
@@ -16,7 +16,6 @@ use vm_memory::{Bytes, GuestMemory};
 
 use crate::configurator::{BootConfigurator, BootParams, Error as BootConfiguratorError, Result};
 
-use std::error::Error as StdError;
 use std::fmt;
 
 /// Boot configurator for the Linux boot protocol.
@@ -31,25 +30,19 @@ pub enum Error {
     ZeroPageSetup,
 }
 
-impl StdError for Error {
-    fn description(&self) -> &str {
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use Error::*;
-        match self {
-            ZeroPagePastRamEnd => "The zero page extends past the end of guest memory.",
-            ZeroPageSetup => "Error writing to the zero page of guest memory.",
-        }
+        let desc = match self {
+            ZeroPagePastRamEnd => "the zero page extends past the end of guest memory.",
+            ZeroPageSetup => "error writing to the zero page of guest memory.",
+        };
+
+        write!(f, "Linux Boot Configurator: {}", desc,)
     }
 }
 
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "Linux Boot Configurator Error: {}",
-            StdError::description(self)
-        )
-    }
-}
+impl std::error::Error for Error {}
 
 impl From<Error> for BootConfiguratorError {
     fn from(err: Error) -> Self {
@@ -183,11 +176,11 @@ mod tests {
     fn test_error_messages() {
         assert_eq!(
             format!("{}", Error::ZeroPagePastRamEnd),
-            "Linux Boot Configurator Error: The zero page extends past the end of guest memory."
+            "Linux Boot Configurator: the zero page extends past the end of guest memory."
         );
         assert_eq!(
             format!("{}", Error::ZeroPageSetup),
-            "Linux Boot Configurator Error: Error writing to the zero page of guest memory."
+            "Linux Boot Configurator: error writing to the zero page of guest memory."
         );
     }
 }

--- a/src/configurator/x86_64/pvh.rs
+++ b/src/configurator/x86_64/pvh.rs
@@ -17,7 +17,6 @@ use vm_memory::{ByteValued, Bytes, GuestMemory};
 use crate::configurator::{BootConfigurator, BootParams, Error as BootConfiguratorError, Result};
 use crate::loader_gen::start_info::{hvm_memmap_table_entry, hvm_modlist_entry, hvm_start_info};
 
-use std::error::Error as StdError;
 use std::fmt;
 
 /// Boot configurator for the PVH boot protocol.
@@ -40,33 +39,27 @@ pub enum Error {
     StartInfoSetup,
 }
 
-impl StdError for Error {
-    fn description(&self) -> &str {
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use Error::*;
-        match self {
+        let desc = match self {
             MemmapTableAddressMissing => {
-                "The starting address for the memory map wasn't passed to the boot configurator."
+                "the starting address for the memory map wasn't passed to the boot configurator."
             }
-            MemmapTableMissing => "No memory map was passed to the boot configurator.",
-            MemmapTablePastRamEnd => "The memory map table extends past the end of guest memory.",
-            MemmapTableSetup => "Error writing memory map table to guest memory.",
+            MemmapTableMissing => "no memory map was passed to the boot configurator.",
+            MemmapTablePastRamEnd => "the memory map table extends past the end of guest memory.",
+            MemmapTableSetup => "error writing memory map table to guest memory.",
             StartInfoPastRamEnd => {
-                "The hvm_start_info structure extends past the end of guest memory."
+                "the hvm_start_info structure extends past the end of guest memory."
             }
-            StartInfoSetup => "Error writing hvm_start_info to guest memory.",
-        }
+            StartInfoSetup => "error writing hvm_start_info to guest memory.",
+        };
+
+        write!(f, "PVH Boot Configurator: {}", desc)
     }
 }
 
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "PVH Boot Configurator Error: {}",
-            StdError::description(self)
-        )
-    }
-}
+impl std::error::Error for Error {}
 
 impl From<Error> for BootConfiguratorError {
     fn from(err: Error) -> Self {
@@ -262,17 +255,20 @@ mod tests {
     fn test_error_messages() {
         assert_eq!(
             format!("{}", Error::MemmapTableMissing),
-            "PVH Boot Configurator Error: No memory map was passed to the boot configurator."
+            "PVH Boot Configurator: no memory map was passed to the boot configurator."
         );
-        assert_eq!(format!("{}", Error::MemmapTablePastRamEnd), "PVH Boot Configurator Error: The memory map table extends past the end of guest memory.");
+        assert_eq!(
+            format!("{}", Error::MemmapTablePastRamEnd),
+            "PVH Boot Configurator: the memory map table extends past the end of guest memory."
+        );
         assert_eq!(
             format!("{}", Error::MemmapTableSetup),
-            "PVH Boot Configurator Error: Error writing memory map table to guest memory."
+            "PVH Boot Configurator: error writing memory map table to guest memory."
         );
-        assert_eq!(format!("{}", Error::StartInfoPastRamEnd), "PVH Boot Configurator Error: The hvm_start_info structure extends past the end of guest memory.");
+        assert_eq!(format!("{}", Error::StartInfoPastRamEnd), "PVH Boot Configurator: the hvm_start_info structure extends past the end of guest memory.");
         assert_eq!(
             format!("{}", Error::StartInfoSetup),
-            "PVH Boot Configurator Error: Error writing hvm_start_info to guest memory."
+            "PVH Boot Configurator: error writing hvm_start_info to guest memory."
         );
     }
 }

--- a/src/loader/aarch64/pe/mod.rs
+++ b/src/loader/aarch64/pe/mod.rs
@@ -12,8 +12,7 @@
 
 #![cfg(feature = "pe")]
 
-use std::error::{self, Error as StdError};
-use std::fmt::{self, Display};
+use std::fmt;
 use std::io::{Read, Seek, SeekFrom};
 use std::mem;
 
@@ -53,29 +52,27 @@ pub enum Error {
     InvalidBaseAddrAlignment,
 }
 
-impl error::Error for Error {
-    fn description(&self) -> &str {
-        match self {
-            Error::SeekImageEnd => "Unable to seek Image end",
-            Error::SeekImageHeader => "Unable to seek Image header",
-            Error::ReadImageHeader => "Unable to read Image header",
-            Error::ReadDtbImage => "Unable to read DTB image",
-            Error::SeekDtbStart => "Unable to seek DTB start",
-            Error::SeekDtbEnd => "Unable to seek DTB end",
-            Error::InvalidImage => "Invalid Image",
-            Error::InvalidImageMagicNumber => "Invalid Image magic number",
-            Error::DtbTooBig => "Device tree image too big",
-            Error::ReadKernelImage => "Unable to read kernel image",
-            Error::InvalidBaseAddrAlignment => "Base address not aligned to 2 MB",
-        }
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let desc = match self {
+            Error::SeekImageEnd => "unable to seek Image end",
+            Error::SeekImageHeader => "unable to seek Image header",
+            Error::ReadImageHeader => "unable to read Image header",
+            Error::ReadDtbImage => "unable to read DTB image",
+            Error::SeekDtbStart => "unable to seek DTB start",
+            Error::SeekDtbEnd => "unable to seek DTB end",
+            Error::InvalidImage => "invalid Image",
+            Error::InvalidImageMagicNumber => "invalid Image magic number",
+            Error::DtbTooBig => "device tree image too big",
+            Error::ReadKernelImage => "unable to read kernel image",
+            Error::InvalidBaseAddrAlignment => "base address not aligned to 2 MB",
+        };
+
+        write!(f, "PE Kernel Loader: {}", desc)
     }
 }
 
-impl Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "PE Kernel Loader Error: {}", self.description())
-    }
-}
+impl std::error::Error for Error {}
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Default)]

--- a/src/loader/x86_64/bzimage/mod.rs
+++ b/src/loader/x86_64/bzimage/mod.rs
@@ -11,8 +11,7 @@
 
 #![cfg(all(feature = "bzimage", any(target_arch = "x86", target_arch = "x86_64")))]
 
-use std::error::{self, Error as StdError};
-use std::fmt::{self, Display};
+use std::fmt;
 use std::io::{Read, Seek, SeekFrom};
 use std::mem;
 
@@ -39,24 +38,22 @@ pub enum Error {
     SeekBzImageCompressedKernel,
 }
 
-impl error::Error for Error {
-    fn description(&self) -> &str {
-        match self {
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let desc = match self {
             Error::InvalidBzImage => "Invalid bzImage",
             Error::ReadBzImageHeader => "Unable to read bzImage header",
             Error::ReadBzImageCompressedKernel => "Unable to read bzImage compressed kernel",
             Error::SeekBzImageEnd => "Unable to seek bzImage end",
             Error::SeekBzImageHeader => "Unable to seek bzImage header",
             Error::SeekBzImageCompressedKernel => "Unable to seek bzImage compressed kernel",
-        }
+        };
+
+        write!(f, "Kernel Loader: {}", desc)
     }
 }
 
-impl Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Kernel Loader Error: {}", self.description())
-    }
-}
+impl std::error::Error for Error {}
 
 /// Big zImage (bzImage) kernel image support.
 pub struct BzImage;

--- a/src/loader/x86_64/elf/mod.rs
+++ b/src/loader/x86_64/elf/mod.rs
@@ -12,8 +12,7 @@
 
 #![cfg(all(feature = "elf", any(target_arch = "x86", target_arch = "x86_64")))]
 
-use std::error::{self, Error as StdError};
-use std::fmt::{self, Display};
+use std::fmt;
 use std::io::{Read, Seek, SeekFrom};
 use std::mem;
 
@@ -62,9 +61,9 @@ pub enum Error {
     InvalidPvhNote,
 }
 
-impl error::Error for Error {
-    fn description(&self) -> &str {
-        match self {
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let desc = match self {
             Error::BigEndianElfOnLittle => {
                 "Trying to load big-endian binary on little-endian machine"
             }
@@ -82,9 +81,13 @@ impl error::Error for Error {
             Error::SeekNoteHeader => "Unable to seek to note header",
             Error::ReadNoteHeader => "Unable to read note header",
             Error::InvalidPvhNote => "Invalid PVH note header",
-        }
+        };
+
+        write!(f, "Kernel Loader: {}", desc)
     }
 }
+
+impl std::error::Error for Error {}
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 /// Availability of PVH entry point in the kernel, which allows the VMM
@@ -104,8 +107,8 @@ impl Default for PvhBootCapability {
     }
 }
 
-impl Display for PvhBootCapability {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> fmt::Result {
+impl fmt::Display for PvhBootCapability {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use self::PvhBootCapability::*;
         match self {
             PvhEntryPresent(pvh_entry_addr) => write!(
@@ -116,12 +119,6 @@ impl Display for PvhBootCapability {
             PvhEntryNotPresent => write!(f, "PVH entry point not present"),
             PvhEntryIgnored => write!(f, "PVH entry point ignored"),
         }
-    }
-}
-
-impl Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Kernel Loader Error: {}", self.description())
     }
 }
 


### PR DESCRIPTION
All Error enumerations except cmdline::Error have implemented
std::error::Error, so add the missing one.

Signed-off-by: Liu Jiang <gerry@linux.alibaba.com>

Please refer to #35 for more information.