### PR TITLE
[RFC] Benchmark tests & integration test demo

### DIFF
--- a/.buildkite/bench_pipeline.yml
+++ b/.buildkite/bench_pipeline.yml
@@ -1,0 +1,26 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+steps:
+  - label: "bench-x86_64"
+    commands:
+      - pytest rust-vmm-ci/integration_tests/test_benchmark.py -s
+    retry:
+      automatic: false
+    agents:
+      platform: x86_64.metal
+    plugins:
+      - docker#v3.0.1:
+          image: "rustvmm/dev:v5_bench"
+          always-pull: true
+
+  - label: "bench-aarch64"
+    commands:
+      - pytest rust-vmm-ci/integration_tests/test_benchmark.py -s
+    retry:
+      automatic: false
+    agents:
+      platform: arm.metal
+    plugins:
+      - docker#v3.0.1:
+          image: "rustvmm/dev:v5_bench"
+          always-pull: true

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "rust-vmm-ci"]
 	path = rust-vmm-ci
-	url = https://github.com/rust-vmm/rust-vmm-ci.git
+    url = https://github.com/aghecenco/rust-vmm-ci.git
+	branch = critcmp

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,15 +4,28 @@ version = "0.1.0"
 authors = ["Cathy Zhang <cathy.zhang@intel.com>"]
 edition = "2018"
 license = "Apache-2.0 AND BSD-3-Clause"
+autobenches = false
 
 [features]
 default = ["elf", "pe"]
-elf = []
 bzimage = []
+elf = []
 pe = []
 
 [dependencies]
 vm-memory = ">=0.2.0"
 
 [dev-dependencies]
+criterion = "=0.3.0"
 vm-memory = {features = ["backend-mmap"]}
+
+[[bench]]
+name = "main"
+harness = false
+
+[lib]
+bench = false # https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
+
+[profile.bench]
+lto = true
+codegen-units = 1

--- a/benches/aarch64/mod.rs
+++ b/benches/aarch64/mod.rs
@@ -1,0 +1,30 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE-BSD-3-Clause file.
+//
+// SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
+extern crate criterion;
+extern crate linux_loader;
+extern crate vm_memory;
+
+use linux_loader::configurator::BootParams;
+use vm_memory::{ByteValued, GuestAddress, GuestMemoryMmap};
+
+const MEM_SIZE: usize = 0x100_0000;
+const FDT_MAX_SIZE: usize = 0x20;
+
+pub fn create_guest_memory() -> GuestMemoryMmap {
+    GuestMemoryMmap::from_ranges(&[(GuestAddress(0x0), MEM_SIZE)]).unwrap()
+}
+
+#[derive(Clone, Copy, Default)]
+pub struct FdtPlaceholder([u8; FDT_MAX_SIZE]);
+
+unsafe impl ByteValued for FdtPlaceholder {}
+
+pub fn build_fdt_boot_params() -> BootParams {
+    let fdt = FdtPlaceholder([0u8; FDT_MAX_SIZE]);
+    let fdt_addr = GuestAddress((MEM_SIZE - FDT_MAX_SIZE - 1) as u64);
+    BootParams::new::<FdtPlaceholder>(&fdt, fdt_addr)
+}

--- a/benches/main.rs
+++ b/benches/main.rs
@@ -1,0 +1,90 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE-BSD-3-Clause file.
+//
+// SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
+extern crate criterion;
+extern crate linux_loader;
+extern crate vm_memory;
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+mod x86_64;
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+use x86_64::*;
+
+#[cfg(target_arch = "aarch64")]
+mod aarch64;
+#[cfg(target_arch = "aarch64")]
+use aarch64::*;
+
+#[cfg(target_arch = "aarch64")]
+use linux_loader::configurator::fdt::FdtBootConfigurator;
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+use linux_loader::configurator::pvh::PvhBootConfigurator;
+use linux_loader::configurator::BootConfigurator;
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+use linux_loader::loader::elf::Elf;
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+use linux_loader::loader::KernelLoader;
+use vm_memory::GuestMemoryMmap;
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+use std::io::Cursor;
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+pub fn criterion_benchmark(c: &mut Criterion) {
+    let guest_mem = create_guest_memory();
+
+    let elf_pvh_image = create_elf_pvh_image();
+    let pvh_boot_params = build_pvh_boot_params();
+
+    c.bench_function("load_elf_pvh", |b| {
+        b.iter(|| {
+            black_box(Elf::load(
+                &guest_mem,
+                None,
+                &mut Cursor::new(&elf_pvh_image),
+                None,
+            ))
+            .unwrap();
+        })
+    });
+
+    c.bench_function("configure_pvh", |b| {
+        b.iter(|| {
+            black_box(PvhBootConfigurator::write_bootparams::<GuestMemoryMmap>(
+                pvh_boot_params.clone(),
+                &guest_mem,
+            ))
+            .unwrap();
+        })
+    });
+}
+
+#[cfg(target_arch = "aarch64")]
+pub fn criterion_benchmark(c: &mut Criterion) {
+    let guest_mem = create_guest_memory();
+    let fdt_boot_params = build_fdt_boot_params();
+    c.bench_function("configure_fdt", |b| {
+        b.iter(|| {
+            black_box(FdtBootConfigurator::write_bootparams::<GuestMemoryMmap>(
+                fdt_boot_params.clone(),
+                &guest_mem,
+            ))
+            .unwrap();
+        })
+    });
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(500);
+    targets = criterion_benchmark
+}
+
+criterion_main! {
+    benches
+}

--- a/benches/x86_64/mod.rs
+++ b/benches/x86_64/mod.rs
@@ -1,0 +1,59 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE-BSD-3-Clause file.
+//
+// SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
+
+#![cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+
+extern crate linux_loader;
+extern crate vm_memory;
+
+use linux_loader::configurator::BootParams;
+use linux_loader::loader::elf::start_info::{hvm_memmap_table_entry, hvm_start_info};
+use vm_memory::{Address, GuestAddress, GuestMemoryMmap};
+
+const MEM_SIZE: usize = 0x100_0000;
+const E820_RAM: u32 = 1;
+const XEN_HVM_START_MAGIC_VALUE: u32 = 0x336ec578;
+
+pub fn create_guest_memory() -> GuestMemoryMmap {
+    GuestMemoryMmap::from_ranges(&[(GuestAddress(0x0), MEM_SIZE)]).unwrap()
+}
+
+pub fn create_elf_pvh_image() -> Vec<u8> {
+    include_bytes!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/src/loader/x86_64/elf/test_elfnote.bin"
+    ))
+    .to_vec()
+}
+
+pub fn build_boot_params() -> (hvm_start_info, Vec<hvm_memmap_table_entry>) {
+    let mut start_info = hvm_start_info::default();
+    let memmap_entry = hvm_memmap_table_entry {
+        addr: 0x7000,
+        size: 0,
+        type_: E820_RAM,
+        reserved: 0,
+    };
+    start_info.magic = XEN_HVM_START_MAGIC_VALUE;
+    start_info.version = 1;
+    start_info.nr_modules = 0;
+    start_info.memmap_entries = 0;
+    (start_info, vec![memmap_entry])
+}
+
+pub fn build_pvh_boot_params() -> BootParams {
+    let (mut start_info, memmap_entries) = build_boot_params();
+    // Address in guest memory where the `start_info` struct will be written.
+    let start_info_addr = GuestAddress(0x6000);
+    // Address in guest memory where the memory map will be written.
+    let memmap_addr = GuestAddress(0x7000);
+    start_info.memmap_paddr = memmap_addr.raw_value();
+    // Write boot parameters in guest memory.
+    let mut boot_params = BootParams::new::<hvm_start_info>(&start_info, start_info_addr);
+    boot_params.set_sections::<hvm_memmap_table_entry>(&memmap_entries, memmap_addr);
+    boot_params
+}


### PR DESCRIPTION
This PR serves several purposes:
1. (the obvious one) add sample benchmark tests that use the [`criterion`](https://github.com/bheisler/criterion.rs) plugin. 2 such tests exercise PVH related code (random choice). The tests can be run locally with `cargo bench`. Note that the numbers are prone to vary significantly between hosts.
1. showcase a proposal for a starting point in the effort of adding performance tests to all `rust-vmm` crates that need them (in the future, all of them) with [`rust-vmm-ci`](https://github.com/rust-vmm/rust-vmm-ci) and dedicated Buildkite pipelines.

**Known caveat**: because the tip of the upstream `linux-loader` does not yet contain benchmarks, the test that tries to extract them & compare is bound to fail. The intention for this PR is to showcase the whole harness (such as it is in its incipient day), get feedback on the approach, then (in case of positive feedback) **first** merge the benchmark tests, then continue with the `rust-vmm-ci` and container changes.
***
The changes can be broken down as follows:
* this crate: benchmark tests are added. They are configured so as not to run as part of `cargo test`.
* [`rust-vmm-ci`](https://github.com/rust-vmm/rust-vmm-ci): a new integration test is added. To showcase how it works, this PR contains a commit that temporarily points the `rust-vmm-ci` submodule to [this branch in my `rust-vmm-ci` fork](https://github.com/aghecenco/rust-vmm-ci/tree/critcmp). The test runs `cargo bench` on the tip of the upstream crate and on the `HEAD` of the PR and compares the results with [`critcmp`](https://github.com/BurntSushi/critcmp). For the moment, the test only prints the results.
* [`rust-vmm-container`](https://github.com/rust-vmm/rust-vmm-container/): a new dev version of the container, `rustvmm/dev:v5_bench`, uploaded to Dockerhub, contains `git` and `critcmp` so that the integration test mentioned above can run.
