### PR TITLE
Enable performance tests at every PR

### DIFF
--- a/.buildkite/bench_pipeline.yml
+++ b/.buildkite/bench_pipeline.yml
@@ -1,0 +1,14 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+steps:
+  - label: "nop"
+    commands:
+     - true
+    retry:
+      automatic: false
+    agents:
+      platform: x86_64.metal
+    plugins:
+      - docker#v3.0.1:
+          image: "rustvmm/dev:v5"
+          always-pull: true

--- a/.buildkite/bench_pipeline.yml
+++ b/.buildkite/bench_pipeline.yml
@@ -1,14 +1,26 @@
 # Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 steps:
-  - label: "nop"
+  - label: "bench-x86_64"
     commands:
-     - true
+      - pytest rust-vmm-ci/integration_tests/test_benchmark.py -s
     retry:
       automatic: false
     agents:
       platform: x86_64.metal
     plugins:
       - docker#v3.0.1:
-          image: "rustvmm/dev:v6"
-          always-pull: true
+        image: "rustvmm/dev:v6"
+        always-pull: true
+
+  - label: "bench-aarch64"
+    commands:
+      - pytest rust-vmm-ci/integration_tests/test_benchmark.py -s
+    retry:
+      automatic: false
+    agents:
+      platform: arm.metal
+    plugins:
+      - docker#v3.0.1:
+        image: "rustvmm/dev:v6"
+        always-pull: true

--- a/.buildkite/bench_pipeline.yml
+++ b/.buildkite/bench_pipeline.yml
@@ -10,5 +10,5 @@ steps:
       platform: x86_64.metal
     plugins:
       - docker#v3.0.1:
-          image: "rustvmm/dev:v5"
+          image: "rustvmm/dev:v6"
           always-pull: true

--- a/.buildkite/hooks/post-checkout
+++ b/.buildkite/hooks/post-checkout
@@ -1,12 +1,12 @@
 #!/bin/bash
 
-DEB_NAME="linux-image-4.9.0-12-amd64_4.9.210-1_amd64.deb"
-DEB_URL="http://ftp.debian.org/debian/pool/main/l/linux/${DEB_NAME}"
+DEB_NAME="kernel-image-4.9.0-13-amd64-di_4.9.228-1_amd64.udeb"
+DEB_URL="http://ftp.us.debian.org/debian/pool/main/l/linux/${DEB_NAME}"
 
 REPO_PATH="${BUILDKITE_BUILD_CHECKOUT_PATH}"
 DEB_PATH="${REPO_PATH}/${DEB_NAME}"
 EXTRACT_PATH="${REPO_PATH}/src/bzimage-archive"
-BZIMAGE_PATH="${EXTRACT_PATH}/boot/vmlinuz-4.9.0-12-amd64"
+BZIMAGE_PATH="${EXTRACT_PATH}/boot/vmlinuz"
 
 mkdir -p ${EXTRACT_PATH}
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,7 +10,7 @@ steps:
       platform: x86_64.metal
     plugins:
       - docker#v3.0.1:
-          image: "rustvmm/dev:v5"
+          image: "rustvmm/dev:v6"
           always-pull: true
 
   - label: "build-musl-x86-bzimage"
@@ -22,5 +22,5 @@ steps:
       platform: x86_64.metal
     plugins:
       - docker#v3.0.1:
-          image: "rustvmm/dev:v5"
+          image: "rustvmm/dev:v6"
           always-pull: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,15 +4,28 @@ version = "0.1.0"
 authors = ["Cathy Zhang <cathy.zhang@intel.com>"]
 edition = "2018"
 license = "Apache-2.0 AND BSD-3-Clause"
+autobenches = false
 
 [features]
 default = ["elf", "pe"]
-elf = []
 bzimage = []
+elf = []
 pe = []
 
 [dependencies]
 vm-memory = ">=0.2.0"
 
 [dev-dependencies]
+criterion = "=0.3.0"
 vm-memory = {features = ["backend-mmap"]}
+
+[[bench]]
+name = "main"
+harness = false
+
+[lib]
+bench = false # https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
+
+[profile.bench]
+lto = true
+codegen-units = 1

--- a/benches/aarch64/mod.rs
+++ b/benches/aarch64/mod.rs
@@ -1,0 +1,48 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE-BSD-3-Clause file.
+//
+// SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
+extern crate criterion;
+extern crate linux_loader;
+extern crate vm_memory;
+
+use linux_loader::configurator::fdt::FdtBootConfigurator;
+use linux_loader::configurator::BootConfigurator;
+use linux_loader::configurator::BootParams;
+use vm_memory::{ByteValued, GuestAddress, GuestMemoryMmap};
+
+use criterion::{black_box, Criterion};
+
+const MEM_SIZE: usize = 0x100_0000;
+const FDT_MAX_SIZE: usize = 0x20;
+
+fn create_guest_memory() -> GuestMemoryMmap {
+    GuestMemoryMmap::from_ranges(&[(GuestAddress(0x0), MEM_SIZE)]).unwrap()
+}
+
+#[derive(Clone, Copy, Default)]
+pub struct FdtPlaceholder([u8; FDT_MAX_SIZE]);
+
+unsafe impl ByteValued for FdtPlaceholder {}
+
+fn build_fdt_boot_params() -> BootParams {
+    let fdt = FdtPlaceholder([0u8; FDT_MAX_SIZE]);
+    let fdt_addr = GuestAddress((MEM_SIZE - FDT_MAX_SIZE - 1) as u64);
+    BootParams::new::<FdtPlaceholder>(&fdt, fdt_addr)
+}
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    let guest_mem = create_guest_memory();
+    let fdt_boot_params = build_fdt_boot_params();
+    c.bench_function("configure_fdt", |b| {
+        b.iter(|| {
+            black_box(FdtBootConfigurator::write_bootparams::<GuestMemoryMmap>(
+                fdt_boot_params.clone(),
+                &guest_mem,
+            ))
+            .unwrap();
+        })
+    });
+}

--- a/benches/main.rs
+++ b/benches/main.rs
@@ -4,6 +4,7 @@
 // found in the LICENSE-BSD-3-Clause file.
 //
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
+
 extern crate criterion;
 extern crate linux_loader;
 extern crate vm_memory;
@@ -20,12 +21,35 @@ mod aarch64;
 #[cfg(target_arch = "aarch64")]
 use aarch64::*;
 
+pub fn criterion_benchmark_nop(_: &mut Criterion) {}
+
 criterion_group! {
     name = benches;
     config = Criterion::default().sample_size(500);
     targets = criterion_benchmark
 }
 
+#[cfg(feature = "bzimage")]
+criterion_group! {
+    name = benches_bzimage;
+    // Only ~125 runs fit in 5 seconds. Either extend the duration, or reduce
+    // the number of iterations.
+    config = Criterion::default().sample_size(100);
+    targets = criterion_benchmark_bzimage
+}
+
+// NOP because the `criterion_main!` macro doesn't support cfg(feature)
+// macro expansions.
+#[cfg(not(feature = "bzimage"))]
+criterion_group! {
+    name = benches_bzimage;
+    // Sample size must be >= 10.
+    // https://github.com/bheisler/criterion.rs/blob/0.3.0/src/lib.rs#L757
+    config = Criterion::default().sample_size(10);
+    targets = criterion_benchmark_nop
+}
+
 criterion_main! {
-    benches
+    benches,
+    benches_bzimage
 }

--- a/benches/main.rs
+++ b/benches/main.rs
@@ -1,0 +1,31 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE-BSD-3-Clause file.
+//
+// SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
+extern crate criterion;
+extern crate linux_loader;
+extern crate vm_memory;
+
+use criterion::{criterion_group, criterion_main, Criterion};
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+mod x86_64;
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+use x86_64::*;
+
+#[cfg(target_arch = "aarch64")]
+mod aarch64;
+#[cfg(target_arch = "aarch64")]
+use aarch64::*;
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(500);
+    targets = criterion_benchmark
+}
+
+criterion_main! {
+    benches
+}

--- a/benches/x86_64/mod.rs
+++ b/benches/x86_64/mod.rs
@@ -1,0 +1,95 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE-BSD-3-Clause file.
+//
+// SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
+
+#![cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+
+extern crate linux_loader;
+extern crate vm_memory;
+
+use linux_loader::configurator::pvh::PvhBootConfigurator;
+use linux_loader::configurator::{BootConfigurator, BootParams};
+use linux_loader::loader::elf::start_info::{hvm_memmap_table_entry, hvm_start_info};
+use linux_loader::loader::elf::Elf;
+use linux_loader::loader::KernelLoader;
+use vm_memory::{Address, GuestAddress, GuestMemoryMmap};
+
+use std::io::Cursor;
+
+use criterion::{black_box, Criterion};
+
+const MEM_SIZE: usize = 0x100_0000;
+const E820_RAM: u32 = 1;
+const XEN_HVM_START_MAGIC_VALUE: u32 = 0x336ec578;
+
+fn create_guest_memory() -> GuestMemoryMmap {
+    GuestMemoryMmap::from_ranges(&[(GuestAddress(0x0), MEM_SIZE)]).unwrap()
+}
+
+fn create_elf_pvh_image() -> Vec<u8> {
+    include_bytes!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/src/loader/x86_64/elf/test_elfnote.bin"
+    ))
+    .to_vec()
+}
+
+fn build_boot_params() -> (hvm_start_info, Vec<hvm_memmap_table_entry>) {
+    let mut start_info = hvm_start_info::default();
+    let memmap_entry = hvm_memmap_table_entry {
+        addr: 0x7000,
+        size: 0,
+        type_: E820_RAM,
+        reserved: 0,
+    };
+    start_info.magic = XEN_HVM_START_MAGIC_VALUE;
+    start_info.version = 1;
+    start_info.nr_modules = 0;
+    start_info.memmap_entries = 0;
+    (start_info, vec![memmap_entry])
+}
+
+fn build_pvh_boot_params() -> BootParams {
+    let (mut start_info, memmap_entries) = build_boot_params();
+    // Address in guest memory where the `start_info` struct will be written.
+    let start_info_addr = GuestAddress(0x6000);
+    // Address in guest memory where the memory map will be written.
+    let memmap_addr = GuestAddress(0x7000);
+    start_info.memmap_paddr = memmap_addr.raw_value();
+    // Write boot parameters in guest memory.
+    let mut boot_params = BootParams::new::<hvm_start_info>(&start_info, start_info_addr);
+    boot_params.set_sections::<hvm_memmap_table_entry>(&memmap_entries, memmap_addr);
+    boot_params
+}
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    let guest_mem = create_guest_memory();
+
+    let elf_pvh_image = create_elf_pvh_image();
+    let pvh_boot_params = build_pvh_boot_params();
+
+    c.bench_function("load_elf_pvh", |b| {
+        b.iter(|| {
+            black_box(Elf::load(
+                &guest_mem,
+                None,
+                &mut Cursor::new(&elf_pvh_image),
+                None,
+            ))
+            .unwrap();
+        })
+    });
+
+    c.bench_function("configure_pvh", |b| {
+        b.iter(|| {
+            black_box(PvhBootConfigurator::write_bootparams::<GuestMemoryMmap>(
+                pvh_boot_params.clone(),
+                &guest_mem,
+            ))
+            .unwrap();
+        })
+    });
+}

--- a/src/loader/x86_64/bzimage/mod.rs
+++ b/src/loader/x86_64/bzimage/mod.rs
@@ -210,7 +210,7 @@ mod tests {
         assert_eq!(loader_result.setup_header.unwrap().header, 0x53726448);
         assert_eq!(loader_result.setup_header.unwrap().version, 0x20d);
         assert_eq!(loader_result.setup_header.unwrap().loadflags, 1);
-        assert_eq!(loader_result.kernel_end, 0x60c320);
+        assert_eq!(loader_result.kernel_end, 0x60D320);
 
         // load bzImage without kernel_offset
         loader_result = BzImage::load(


### PR DESCRIPTION
**This PR is on top of #44. Please review only the last 3 commits. #44 should be merged first.**

This PR hooks `linux-loader` to the recently introduced bench integration test in rust-vmm-ci. The benchmarks introduced by #44 will be run at every PR and the test will print comparison results relative to the upstream code.