### PR TITLE
Force UTF-8 encoding in custom pipeline and block criterion version

### DIFF
--- a/.buildkite/bench_pipeline.yml
+++ b/.buildkite/bench_pipeline.yml
@@ -12,6 +12,8 @@ steps:
       - docker#v3.0.1:
           image: "rustvmm/dev:v6"
           always-pull: true
+          environment:
+            - "PYTHONIOENCODING=utf-8"
           propagate-environment: true
 
   - label: "bench-aarch64"
@@ -25,4 +27,6 @@ steps:
       - docker#v3.0.1:
           image: "rustvmm/dev:v6"
           always-pull: true
+          environment:
+            - "PYTHONIOENCODING=utf-8"
           propagate-environment: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ pe = []
 vm-memory = ">=0.2.0"
 
 [dev-dependencies]
-criterion = ">=0.3.0"
+criterion = "=0.3.0"
 vm-memory = {features = ["backend-mmap"]}
 
 [[bench]]


### PR DESCRIPTION
This prevents Unicode encoding errors when printing to `stdout` from the benchmark integ test and stabilizes `criterion` output.