### PR TITLE
Specify serial console & virtio MMIO devices to the kernel command line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Added functions for specifying virtio MMIO devices when building the kernel
   command line.
+- Added a function to specify multiple values in `key=values` pairs when
+  building the kernel command line.
 
 # [v0.2.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Added
 
+- Added functions for specifying virtio MMIO devices when building the kernel
+  command line.
+
+# [v0.2.0]
+
+## Added
+
 - Added traits and structs for loading ELF (`vmlinux`), big zImage (`bzImage`)
   and PE (`Image`) kernels into guest memory.
 - Added traits and structs for writing boot parameters to guest memory.

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 79.2,
+  "coverage_score": 80.1,
   "exclude_path": "",
   "crate_features": "bzimage,elf",
   "exclude_path": "benches/,loader_gen/"


### PR DESCRIPTION
This PR extends the `Cmdline` with the possibility of specifying serial console and virtio MMIO device configurations, which are transparently stringified and appended to the command line.