### PR TITLE
Run unit tests on local dev machines

### DIFF
--- a/.buildkite/download_resources.sh
+++ b/.buildkite/download_resources.sh
@@ -13,7 +13,7 @@ SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 
 mkdir -p ${EXTRACT_PATH}
 
-wget $DEB_URL -P ${TMP_PATH}
+curl $DEB_URL -o ${DEB_PATH}
 dpkg-deb -x ${DEB_PATH} ${EXTRACT_PATH}
 
 mv ${BZIMAGE_PATH} "${SCRIPTPATH}/../src/loader/x86_64/bzimage/bzimage"

--- a/.buildkite/hooks/post-checkout
+++ b/.buildkite/hooks/post-checkout
@@ -1,18 +1,21 @@
 #!/bin/bash
 
+set -e
+
 DEB_NAME="kernel-image-4.9.0-13-amd64-di_4.9.228-1_amd64.udeb"
 DEB_URL="http://ftp.us.debian.org/debian/pool/main/l/linux/${DEB_NAME}"
 
-REPO_PATH="${BUILDKITE_BUILD_CHECKOUT_PATH}"
-DEB_PATH="${REPO_PATH}/${DEB_NAME}"
-EXTRACT_PATH="${REPO_PATH}/src/bzimage-archive"
+TMP_PATH="/tmp/linux-loader/"
+DEB_PATH="${TMP_PATH}/${DEB_NAME}"
+EXTRACT_PATH="${TMP_PATH}/src/bzimage-archive"
 BZIMAGE_PATH="${EXTRACT_PATH}/boot/vmlinuz"
+SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 
 mkdir -p ${EXTRACT_PATH}
 
-wget $DEB_URL -P ${REPO_PATH}
+wget $DEB_URL -P ${TMP_PATH}
 dpkg-deb -x ${DEB_PATH} ${EXTRACT_PATH}
 
-mv ${BZIMAGE_PATH} ${REPO_PATH}/src/loader/x86_64/bzimage/bzimage
+mv ${BZIMAGE_PATH} "${SCRIPTPATH}/../src/loader/x86_64/bzimage/bzimage"
 rm -r ${EXTRACT_PATH}
 rm -f ${DEB_PATH}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ vm-memory = ">=0.2.0"
 
 [dev-dependencies]
 criterion = "=0.3.0"
-vm-memory = {features = ["backend-mmap"]}
+vm-memory = { version = ">=0.2.0", features = ["backend-mmap"] }
 
 [[bench]]
 name = "main"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,13 @@
+use std::process::Command;
+
+fn main() {
+    let command = "./.buildkite/download_resources.sh";
+    let status = Command::new(command).status().unwrap();
+    if !status.success() {
+        panic!("Cannot run build script");
+    }
+
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=.buildkite/download_resources.sh");
+    println!("cargo:rerun-if-changed=src/loader/x86_64/bzimage/bzimage");
+}


### PR DESCRIPTION
This PR removes the buildkite hooks and makes it possible to run the unit tests on local dev machines as well by downloading the required resources for running the test as part of a rust build script.