### PR TITLE
elf: `align_up` usage susceptible to data loss

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 81.0,
+  "coverage_score": 80.8,
   "exclude_path": "",
   "crate_features": "bzimage,elf",
   "exclude_path": "benches/,loader_gen/"


### PR DESCRIPTION
In response to #66.

* While using `aling_up` we're converting the function result
to other data types. The conversions were double checked and
comments were added to clarify why they are safe.

   