### PR TITLE
release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+# [v0.6.0]
+
+## Changed
+- Crate is now using edition 2021.
+
+## Added
+- Derived `Eq` for `Error` types and the `PvhBootCapability` enum.
+
+## Fixed
+- Fixed a bug in `load_cmdline` due to which the command line was not null
+  terminated. This resulted in a change in the `Cmdline` API where instead of
+  returning the cmdline as a String, we're now returning it as a `CString` as
+  the latter has support for converting it to a null terminated bytes array.
+- Fixed an off-by-one error in load_cmdline, where we were doing validations
+  on the first address after the command line memory region, instead of the
+  last inclusive one of it.
+
 # [v0.5.0]
 
 ## Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linux-loader"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Cathy Zhang <cathy.zhang@intel.com>"]
 edition = "2021"
 license = "Apache-2.0 AND BSD-3-Clause"


### PR DESCRIPTION
### Summary of the PR

Details in the CHANGELOG.

**NOTE**: once we publish the new version I will yank v0.4.0 and v0.5.0 because of a critical bug in the way we're loading the kernel command line into guest memory. The 2 aforemntioned releases do not write a null terminator at the end of the command line which means that the kernel might end up reading past the intended command line size. This is typically not the case in a common VMM scenario because the Guest Memory is typically zeroed, so we do get a null terminated command line by luck.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] Any newly added `unsafe` code is properly documented.
