### PR TITLE
loader: x86_64: elf: Avoid reading beyond file end

### DIFF
--- a/src/loader/x86_64/elf/mod.rs
+++ b/src/loader/x86_64/elf/mod.rs
@@ -217,8 +217,8 @@ impl KernelLoader for Elf {
             .map_err(|_| Error::SeekElfStart)?;
 
         let mut ehdr = elf::Elf64_Ehdr::default();
-        ehdr.as_bytes()
-            .read_from(0, kernel_image, mem::size_of::<elf::Elf64_Ehdr>())
+        kernel_image
+            .read_exact(ehdr.as_mut_slice())
             .map_err(|_| Error::ReadElfHeader)?;
 
         // Sanity checks.
@@ -246,12 +246,11 @@ impl KernelLoader for Elf {
             .seek(SeekFrom::Start(ehdr.e_phoff))
             .map_err(|_| Error::SeekProgramHeader)?;
 
-        let phdr_sz = mem::size_of::<elf::Elf64_Phdr>();
         let mut phdrs: Vec<elf::Elf64_Phdr> = vec![];
         for _ in 0usize..ehdr.e_phnum as usize {
             let mut phdr = elf::Elf64_Phdr::default();
-            phdr.as_bytes()
-                .read_from(0, kernel_image, phdr_sz)
+            kernel_image
+                .read_exact(phdr.as_mut_slice())
                 .map_err(|_| Error::ReadProgramHeader)?;
             phdrs.push(phdr);
         }
@@ -335,8 +334,8 @@ where
     let nhdr_sz = mem::size_of::<elf::Elf64_Nhdr>();
 
     while read_size < phdr.p_filesz as usize {
-        nhdr.as_bytes()
-            .read_from(0, kernel_image, nhdr_sz)
+        kernel_image
+            .read_exact(nhdr.as_mut_slice())
             .map_err(|_| Error::ReadNoteHeader)?;
 
         // Check if the note header's name and type match the ones specified by the PVH ABI.


### PR DESCRIPTION
### Summary of the PR

The ELF header contains offsets that the loader uses to find other structures. If those offsets are beyond the end of the file (or would go past the end of the file) it is essential to error out when attempting to read those. Using `Read::read_exact()` permits this.

Signed-off-by: Bo Chen <chen.bo@intel.com>
Co-authored-by: Rob Bradford <robert.bradford@intel.com>

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
