### PR TITLE
[tests]: Move values of setup_header on stack

### DIFF
--- a/src/loader/x86_64/bzimage/mod.rs
+++ b/src/loader/x86_64/bzimage/mod.rs
@@ -238,20 +238,16 @@ mod tests {
         )
         .unwrap();
         let setup_header = loader_result.setup_header.unwrap();
+        let header = setup_header.header;
+        let version = setup_header.version;
 
         assert_eq!(loader_result.kernel_load.raw_value(), 0x200000);
         assert_eq!(
-            // SAFETY:
-            // Reading the value from an unaligned address is not considered safe.
-            // but this is not an issue since this is a test.
-            unsafe { std::ptr::addr_of!(setup_header.header).read_unaligned() },
+            header,
             0x53726448
         );
         assert_eq!(
-            // SAFETY:
-            // Reading the value from an unaligned address is not considered safe.
-            // but this is not an issue since this is a test.
-            unsafe { std::ptr::addr_of!(setup_header.version).read_unaligned() },
+            version,
             0x20d
         );
         assert_eq!(loader_result.setup_header.unwrap().loadflags, 1);
@@ -266,18 +262,15 @@ mod tests {
         )
         .unwrap();
         let setup_header = loader_result.setup_header.unwrap();
+        let header = setup_header.header;
 
         assert_eq!(loader_result.kernel_load.raw_value(), 0x100000);
 
         // load bzImage without himem_start
         loader_result = BzImage::load(&gm, None, &mut Cursor::new(&image), None).unwrap();
-        // Reading the value from an unaligned address is not considered safe.
         assert_eq!(
             0x53726448,
-            // SAFETY:
-            // Reading the value from an unaligned address is not considered safe.
-            // but this is not an issue since this is a test.
-            unsafe { std::ptr::addr_of!(setup_header.header).read_unaligned() }
+            header
         );
         assert_eq!(loader_result.kernel_load.raw_value(), 0x100000);
 


### PR DESCRIPTION
### Summary of the PR

Calling `read_unaligned` requires an unsafe block. However it is safe to move the value of the required fields on the stack.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
