### PR TITLE
Enable dependabot for rust dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,5 +3,11 @@ updates:
 - package-ecosystem: gitsubmodule
   directory: "/"
   schedule:
-    interval: monthly
+    interval: weekly
+  open-pull-requests-limit: 1
+- package-ecosystem: cargo
+  directory: "/"
+  schedule: 
+    interval: weekly
   open-pull-requests-limit: 10
+  rebase-strategy: "disabled"


### PR DESCRIPTION
### Summary of the PR

Also increases the frequency for rust-vmm-ci submodules updates to once a week, and limits the number of simultaneous PRs for it to one. This brings the configuration in-line with vm-allocator and vm-memory.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
