### PR TITLE
Fixing kernel commandline parameter validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Upcoming Release
+## Changed
+- [[#148](https://github.com/rust-vmm/linux-loader/pull/148)] Fixing kernel commandline parameter validation
+  This change allows parameter values containing spaces in the middle, provided they are enclosed in quotes. However, 
+  strings with quotes in the middle will no longer be accepted as valid parameter values.
 
 # [v0.13.0]
 

--- a/src/cmdline/mod.rs
+++ b/src/cmdline/mod.rs
@@ -104,7 +104,7 @@ fn contains_double_quotes(s: &str) -> bool {
     if s.len() < 3 {
         return false;
     }
-    return s.chars().skip(1).take(s.len() - 2).any(|c| c == '"');
+    s.chars().skip(1).take(s.len() - 2).any(|c| c == '"')
 }
 
 fn valid_key(s: &str) -> Result<()> {


### PR DESCRIPTION
According to linux kernel document, the value of command line parameter can contains spaces (with double quotes) or equals.

### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
