### PR TITLE
Update bzimage kernel image download path

### DIFF
--- a/.buildkite/download_resources.sh
+++ b/.buildkite/download_resources.sh
@@ -2,13 +2,13 @@
 
 set -e
 
-DEB_NAME="kernel-image-4.9.0-13-amd64-di_4.9.228-1_amd64.udeb"
+DEB_NAME="linux-image-5.10.0-22-amd64-unsigned_5.10.178-3_amd64.deb"
 DEB_URL="http://ftp.us.debian.org/debian/pool/main/l/linux/${DEB_NAME}"
 
 TMP_PATH="/tmp/linux-loader/"
 DEB_PATH="${TMP_PATH}/${DEB_NAME}"
 EXTRACT_PATH="${TMP_PATH}/src/bzimage-archive"
-BZIMAGE_PATH="${EXTRACT_PATH}/boot/vmlinuz"
+BZIMAGE_PATH="${EXTRACT_PATH}/boot/vmlinuz-5.10.0-22-amd64"
 SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 
 mkdir -p ${EXTRACT_PATH}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ pe = []
 vm-memory = "0.11.0"
 
 [dev-dependencies]
-criterion = "0.3.5"
+criterion = { version = "0.3.5", features = ["html_reports"] }
 vm-memory = { version = "0.11.0", features = ["backend-mmap"] }
 
 [[bench]]

--- a/src/loader/x86_64/bzimage/mod.rs
+++ b/src/loader/x86_64/bzimage/mod.rs
@@ -252,10 +252,10 @@ mod tests {
             // Reading the value from an unaligned address is not considered safe.
             // but this is not an issue since this is a test.
             unsafe { std::ptr::addr_of!(setup_header.version).read_unaligned() },
-            0x20d
+            0x20f
         );
         assert_eq!(loader_result.setup_header.unwrap().loadflags, 1);
-        assert_eq!(loader_result.kernel_end, 0x60D320);
+        assert_eq!(loader_result.kernel_end, 0x8B1600);
 
         // load bzImage without kernel_offset
         loader_result = BzImage::load(


### PR DESCRIPTION
### Summary of the PR

The integ tests used to download a 4.9 kernel image from the Debian servers, which has been since taken down. Updating to a 5.10 image and adjusting the tests accordingly.

Fixes #149

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
