### PR TITLE
Build docs.rs documentation with features enabled and other fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Upcoming version
+
+## Changed
+
+- Added all features to the generated docs.rs documentation.
+
 # [v0.10.0]
 
 ## Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,10 @@ homepage = "https://github.com/rust-vmm/linux-loader"
 readme = "README.md"
 autobenches = false
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [features]
 default = ["elf", "pe"]
 bzimage = []

--- a/src/cmdline/mod.rs
+++ b/src/cmdline/mod.rs
@@ -324,7 +324,7 @@ impl Cmdline {
 
     /// Returns a C compatible representation of the command line
     /// The Linux kernel expects a null terminated cmdline according to the source:
-    /// https://elixir.bootlin.com/linux/v5.10.139/source/kernel/params.c#L179
+    /// <https://elixir.bootlin.com/linux/v5.10.139/source/kernel/params.c#L179>
     ///
     /// To get bytes of the cmdline to be written in guest's memory (including the
     /// null terminator) from this representation, use CString::as_bytes_with_nul()

--- a/src/cmdline/mod.rs
+++ b/src/cmdline/mod.rs
@@ -433,12 +433,14 @@ impl Cmdline {
         slug.matches('\"').count() % 2 == 0
     }
 
-    /// Tries to build a [`Cmdline`] with a given capacity from a str. The format of the
-    /// str provided must be one of the followings:
-    /// -> <boot args> -- <init args>
-    /// -> <boot args>
-    /// where <boot args> and <init args> can contain '--' only if double quoted and
-    /// <boot args> and <init args> contain at least one non-whitespace char each.
+    /// Tries to build a [`Cmdline`] with a given capacity from a [`str`]. The format of the
+    /// str provided must be one of the following:
+    ///
+    /// * `<boot args> -- <init args>`
+    /// * `<boot args>`
+    ///
+    /// where `<boot args>` and `<init args>` can contain `--` only if double quoted and
+    /// `<boot args>` and `<init args>` contain at least one non-whitespace char each.
     ///
     /// Providing a str not following these rules might end up in undefined behaviour of
     /// the resulting `Cmdline`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 
 #![deny(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 //! A Linux kernel image loading crate.
 //!

--- a/src/loader/mod.rs
+++ b/src/loader/mod.rs
@@ -147,12 +147,12 @@ pub struct KernelLoaderResult {
     /// blob and initrd will be loaded adjacent to kernel image.
     pub kernel_end: GuestUsize,
     /// Configuration for the VMM to use to fill zero page for bzImage direct boot.
-    /// See https://www.kernel.org/doc/Documentation/x86/boot.txt.
+    /// See <https://www.kernel.org/doc/Documentation/x86/boot.txt>.
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     pub setup_header: Option<bootparam::setup_header>,
     /// Availability of a PVH entry point. Only used for ELF boot, indicates whether the kernel
     /// supports the PVH boot protocol as described in:
-    /// https://xenbits.xen.org/docs/unstable/misc/pvh.html
+    /// <https://xenbits.xen.org/docs/unstable/misc/pvh.html>
     #[cfg(all(feature = "elf", any(target_arch = "x86", target_arch = "x86_64")))]
     pub pvh_boot_cap: elf::PvhBootCapability,
 }


### PR DESCRIPTION
### Summary of the PR

* Build docs.rs documentation with features enabled, since they do not show up at the moment.
* Fix rustdoc warnings about bare URLs.
* Fix rustdoc warnings about invalid HTML tags.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- `N/A` All added/changed functionality has a corresponding unit/integration
  test.
- [X] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- `N/A` Any newly added `unsafe` code is properly documented.
