### PR TITLE
aarch64: Remove redundant bench

### DIFF
--- a/benches/main.rs
+++ b/benches/main.rs
@@ -21,37 +21,12 @@ mod aarch64;
 #[cfg(target_arch = "aarch64")]
 use aarch64::*;
 
-pub fn criterion_benchmark_nop(_: &mut Criterion) {}
-
 criterion_group! {
     name = benches;
     config = Criterion::default().sample_size(500);
     targets = criterion_benchmark
 }
 
-#[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "bzimage"))]
-// Explicit (arch, feature) tuple required as clippy complains about
-// `criterion_benchmark_bzimage` missing on aarch64.
-criterion_group! {
-    name = benches_bzimage;
-    // Only ~125 runs fit in 5 seconds. Either extend the duration, or reduce
-    // the number of iterations.
-    config = Criterion::default().sample_size(100);
-    targets = criterion_benchmark_bzimage
-}
-
-// NOP because the `criterion_main!` macro doesn't support cfg(feature)
-// macro expansions.
-#[cfg(any(target_arch = "aarch64", not(feature = "bzimage")))]
-criterion_group! {
-    name = benches_bzimage;
-    // Sample size must be >= 10.
-    // https://github.com/bheisler/criterion.rs/blob/0.3.0/src/lib.rs#L757
-    config = Criterion::default().sample_size(10);
-    targets = criterion_benchmark_nop
-}
-
 criterion_main! {
-    benches,
-    benches_bzimage
+    benches
 }

--- a/benches/x86_64/mod.rs
+++ b/benches/x86_64/mod.rs
@@ -120,13 +120,11 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             .unwrap();
         })
     });
-}
 
-#[cfg(feature = "bzimage")]
-pub fn criterion_benchmark_bzimage(c: &mut Criterion) {
-    let guest_mem = create_guest_memory();
+    #[cfg(feature = "bzimage")]
     let bzimage = create_bzimage();
 
+    #[cfg(feature = "bzimage")]
     c.bench_function("load_bzimage", |b| {
         b.iter(|| {
             black_box(BzImage::load(


### PR DESCRIPTION
### Summary of the PR

The `criterion_benchmark_nop` function does literally nothing, there is no need to run these benchs.

Re-organize the code to run `benches_bzimage` on x86 and x86_64 machines with `bzimage` feature enabled.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
