### PR TITLE
chore: Prepare 0.13.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Upcoming Release
 
+# [v0.13.0]
+
 ## Added
 
 - [[#190](https://github.com/rust-vmm/linux-loader/pull/190)] Introduce RISC-V64
@@ -7,6 +9,7 @@
 
 ## Changed
 
+- [[#194](https://github.com/rust-vmm/linux-loader/pull/194)] Updated vm-memory to 0.16.0.
 - [[#197](https://github.com/rust-vmm/linux-loader/pull/197)] Re-organize
   `loader`, `configurator` and `benches` module layout, leaving original interface
   intact.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linux-loader"
-version = "0.12.0"
+version = "0.13.0"
 authors = [
     "The rust-vmm maintainers",
     "rust-vmm AWS maintainers <rust-vmm-maintainers@amazon.com>",


### PR DESCRIPTION
### Summary of the PR

linux-loader 0.13.0 incorporates:

- Introduce RISC-V64 architecture support.
- Updated vm-memory to 0.16.0.
- Re-organize `loader`, `configurator` and `benches` module layout, leaving original interface intact.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
