### PR TITLE
ci: add crates.io publish workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,19 @@
+name: Publish to crates.io
+
+on:
+  push:
+    tags: ['v*']  # Triggers when pushing tags starting with 'v'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    # environment: release  # Optional: for enhanced security
+    permissions:
+      id-token: write     # Required for OIDC token exchange
+    steps:
+    - uses: actions/checkout@v4
+    - uses: rust-lang/crates-io-auth-action@v1
+      id: auth
+    - run: cargo publish
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
Add a trusted publishing workflow for crates.io. It will be triggered everytime there's a push of a tag starting with `v`.

The workflow must be manually added to crates.io:

> Configuring Trusted Publishing
>
> Configure your crate on crates.io:
>
>     Go to your crate's Settings → Trusted Publishing
>     Click the "Add" button and fill in:
>         Repository owner: Your GitHub username or organization
>         Repository name: The name of your repository
>         Workflow filename: The filename of your GitHub Actions workflow (e.g., "release.yml")
>         Environment: Optional environment name if you're using GitHub environments
>     Save the configuration

Documentation: https://crates.io/docs/trusted-publishing

cc @roypat 

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
