### PR TITLE
fix(test): make dev-deps and deps version ranges match

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ vm-memory = ">=0.16.0,<=0.17.0"
 
 [dev-dependencies]
 criterion = { version = "0.7.0", features = ["html_reports"] }
-vm-memory = { version = "0.17.0", features = ["backend-mmap"] }
+vm-memory = { version = ">=0.16.0,<=0.17.0", features = ["backend-mmap"] }
 
 [[bench]]
 name = "main"


### PR DESCRIPTION
otherwise, the benchmarks pick vm-memory 0.17.x but the library target can pick 0.16.y and then the benchmarks fail to compile (due to how the benchmarks utilize A/B-testing, this PR might fail CI similarly to linux-loader#210, in which case we'll need to force merge).

### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
