### PR TITLE
chore(deps): bump vm-memory and criterion versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,11 +26,11 @@ pe = ["elf"]
 elf = []
 
 [dependencies]
-vm-memory = ">=0.16.0, <=0.17.1"
+vm-memory = { version = "0.18.0" }
 
 [dev-dependencies]
-criterion = { version = "0.7.0", features = ["html_reports"] }
-vm-memory = { version = ">=0.16.0, <=0.17.1", features = ["backend-mmap"] }
+criterion = { version = "0.8.1", features = ["html_reports"] }
+vm-memory = { version = "0.18.0", features = ["backend-mmap"] }
 
 [[bench]]
 name = "main"

--- a/src/configurator/fdt.rs
+++ b/src/configurator/fdt.rs
@@ -3,8 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 
 //! Traits and structs for loading the device tree.
-
-use vm_memory::{Bytes, GuestMemory};
+use vm_memory::{Bytes, GuestMemory, GuestMemoryBackend};
 
 use std::fmt;
 
@@ -56,7 +55,7 @@ impl BootConfigurator for FdtBootConfigurator {
     /// # extern crate vm_memory;
     /// # use linux_loader::configurator::{BootConfigurator, BootParams};
     /// # use linux_loader::configurator::fdt::FdtBootConfigurator;
-    /// # use vm_memory::{Address, ByteValued, GuestMemory, GuestMemoryMmap, GuestAddress};
+    /// # use vm_memory::{Address, ByteValued, GuestMemory, GuestMemoryBackend, GuestMemoryMmap, GuestAddress};
     /// # #[derive(Clone, Copy, Default)]
     /// # struct FdtPlaceholder([u8; 0x20]);
     /// # unsafe impl ByteValued for FdtPlaceholder {}
@@ -79,7 +78,7 @@ impl BootConfigurator for FdtBootConfigurator {
     /// ```
     fn write_bootparams<M>(params: &BootParams, guest_memory: &M) -> Result<()>
     where
-        M: GuestMemory,
+        M: GuestMemory + GuestMemoryBackend,
     {
         guest_memory
             .checked_offset(params.header_start, params.header.len())

--- a/src/configurator/mod.rs
+++ b/src/configurator/mod.rs
@@ -18,7 +18,7 @@
 
 #![cfg(any(feature = "elf", feature = "pe", feature = "bzimage"))]
 
-use vm_memory::{Address, ByteValued, GuestAddress, GuestMemory};
+use vm_memory::{Address, ByteValued, GuestAddress, GuestMemory, GuestMemoryBackend};
 
 use std::fmt;
 
@@ -123,7 +123,7 @@ pub trait BootConfigurator {
     /// * `guest_memory` - guest's physical memory.
     fn write_bootparams<M>(params: &BootParams, guest_memory: &M) -> Result<()>
     where
-        M: GuestMemory;
+        M: GuestMemory + GuestMemoryBackend;
 }
 
 /// Boot parameters to be written in guest memory.

--- a/src/configurator/x86_64/linux.rs
+++ b/src/configurator/x86_64/linux.rs
@@ -12,7 +12,7 @@
 //! Traits and structs for configuring and loading boot parameters on `x86_64` using the Linux
 //! boot protocol.
 
-use vm_memory::{Bytes, GuestMemory};
+use vm_memory::{Bytes, GuestMemory, GuestMemoryBackend};
 
 use crate::configurator::{BootConfigurator, BootParams, Error as BootConfiguratorError, Result};
 
@@ -97,7 +97,7 @@ impl BootConfigurator for LinuxBootConfigurator {
     /// [`boot_params`]: ../loader/bootparam/struct.boot_params.html
     fn write_bootparams<M>(params: &BootParams, guest_memory: &M) -> Result<()>
     where
-        M: GuestMemory,
+        M: GuestMemory + GuestMemoryBackend,
     {
         // The VMM has filled a `boot_params` struct and its e820 map.
         // This will be written in guest memory at the zero page.

--- a/src/configurator/x86_64/pvh.rs
+++ b/src/configurator/x86_64/pvh.rs
@@ -14,7 +14,7 @@
 
 #![cfg(any(feature = "elf", feature = "bzimage"))]
 
-use vm_memory::{ByteValued, Bytes, GuestMemory};
+use vm_memory::{ByteValued, Bytes, GuestMemory, GuestMemoryBackend};
 
 use crate::configurator::{BootConfigurator, BootParams, Error as BootConfiguratorError, Result};
 use crate::loader_gen::start_info::{hvm_memmap_table_entry, hvm_modlist_entry, hvm_start_info};
@@ -145,7 +145,7 @@ impl BootConfigurator for PvhBootConfigurator {
     /// ```
     fn write_bootparams<M>(params: &BootParams, guest_memory: &M) -> Result<()>
     where
-        M: GuestMemory,
+        M: GuestMemory + GuestMemoryBackend,
     {
         // The VMM has filled an `hvm_start_info` struct and a `Vec<hvm_memmap_table_entry>`
         // and has passed them on to this function.

--- a/src/loader/mod.rs
+++ b/src/loader/mod.rs
@@ -24,7 +24,9 @@ use std::io::{Read, Seek};
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 use vm_memory::ByteValued;
-use vm_memory::{Address, Bytes, GuestAddress, GuestMemory, GuestUsize, ReadVolatile};
+use vm_memory::{
+    Address, Bytes, GuestAddress, GuestMemory, GuestMemoryBackend, GuestUsize, ReadVolatile,
+};
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub use crate::loader_gen::bootparam;
@@ -219,7 +221,7 @@ unsafe impl ByteValued for bootparam::boot_params {}
 /// let result = load_cmdline(&gm, GuestAddress(0x1000), &cl).unwrap();
 /// gm.read_slice(buf.as_mut_slice(), GuestAddress(0x1000)).unwrap();
 /// assert_eq!(buf.as_slice(), "foo=bar\0".as_bytes());
-pub fn load_cmdline<M: GuestMemory>(
+pub fn load_cmdline<M: GuestMemory + GuestMemoryBackend>(
     guest_mem: &M,
     guest_addr: GuestAddress,
     cmdline: &Cmdline,


### PR DESCRIPTION

### Summary of the PR

Bumped maximum vm-memory version to 0.18.0.
Also bumped criterion to 0.8.1.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
