### PR TITLE
Disable vm-memory default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,11 +26,11 @@ pe = ["elf"]
 elf = []
 
 [dependencies]
-vm-memory = ">=0.16.0, <=0.17.1"
+vm-memory = { version = ">=0.16.0, <=0.17.1", default-features = false }
 
 [dev-dependencies]
 criterion = { version = "0.7.0", features = ["html_reports"] }
-vm-memory = { version = ">=0.16.0, <=0.17.1", features = ["backend-mmap"] }
+vm-memory = { version = ">=0.16.0, <=0.17.1", default-features = false, features = ["backend-mmap"] }
 
 [[bench]]
 name = "main"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,11 +26,11 @@ pe = ["elf"]
 elf = []
 
 [dependencies]
-vm-memory = "0.18"
+vm-memory = { version = "0.18", default-features = false }
 
 [dev-dependencies]
 criterion = { version = "0.7.0", features = ["html_reports"] }
-vm-memory = { version = "0.18", features = ["backend-mmap"] }
+vm-memory = { version = "0.18", default-features = false, features = ["backend-mmap"] }
 
 [[bench]]
 name = "main"

--- a/src/loader_gen/x86_64/bootparam.rs
+++ b/src/loader_gen/x86_64/bootparam.rs
@@ -218,6 +218,8 @@ pub struct __kernel_fd_set {
     pub fds_bits: [::std::os::raw::c_ulong; 16usize],
 }
 #[test]
+// On Windows the unsigned long size is 4 bytes, instead of 8
+#[cfg(target_family = "unix")]
 fn bindgen_test_layout___kernel_fd_set() {
     const UNINIT: ::std::mem::MaybeUninit<__kernel_fd_set> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();


### PR DESCRIPTION
### Summary of the PR

By default vm-memory enables the "rawfd" feature, which causes the compilation to fail on windows.

### Requirements

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
